### PR TITLE
Transactions v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.freeze
+*.log
 *.swo
 *.swp
 .old

--- a/src/engine/database/cosmos.rs
+++ b/src/engine/database/cosmos.rs
@@ -935,6 +935,7 @@ impl Transaction for CosmosTransaction {
         &mut self,
         query: String,
         params: HashMap<String, Value>,
+        src_var: &str,
         _src_label: &str,
         _src_suffix: &str,
         rel_name: &str,
@@ -953,14 +954,17 @@ impl Transaction for CosmosTransaction {
             let query = if top_level_query {
                 query + ".E().hasLabel('" + rel_name + "').has('partitionKey', partitionKey)"
             } else {
-                query + ".outE('" + rel_name + "')"
+                query + ".select('" + src_var + "').outE('" + rel_name + "')"
                 // query + "outE('" + rel_name + "')"
             };
 
             // query = CosmosTransaction::add_has_id_clause(query, rel_ids)?;
 
             let (mut query, params) = CosmosTransaction::add_properties(query, params, props, sg);
-            query = CosmosTransaction::add_rel_return(query);
+
+            if top_level_query {
+                query = CosmosTransaction::add_rel_return(query);
+            }
 
             Ok((query, params))
         } else {

--- a/src/engine/database/mod.rs
+++ b/src/engine/database/mod.rs
@@ -305,6 +305,7 @@ pub(crate) struct NodeQueryVar {
 }
 
 impl NodeQueryVar {
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     pub(crate) fn new(label: Option<String>, base: String, suffix: String) -> NodeQueryVar {
         NodeQueryVar {
             base: base.clone(),
@@ -314,18 +315,22 @@ impl NodeQueryVar {
         }
     }
 
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     pub(crate) fn base(&self) -> &str {
         &self.base
     }
 
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     pub(crate) fn label(&self) -> Result<&str, Error> {
         self.label.as_deref().ok_or_else(|| Error::LabelNotFound)
     }
 
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     pub(crate) fn suffix(&self) -> &str {
         &self.suffix
     }
 
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     pub(crate) fn name(&self) -> &str {
         &self.name
     }
@@ -341,6 +346,7 @@ pub(crate) struct RelQueryVar {
 }
 
 impl RelQueryVar {
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     pub(crate) fn new(
         label: String,
         suffix: String,
@@ -356,18 +362,22 @@ impl RelQueryVar {
         }
     }
 
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     pub(crate) fn label(&self) -> &str {
         &self.label
     }
 
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     pub(crate) fn name(&self) -> &str {
         &self.name
     }
 
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     pub(crate) fn src(&self) -> &NodeQueryVar {
         &self.src
     }
 
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     pub(crate) fn dst(&self) -> &NodeQueryVar {
         &self.dst
     }
@@ -375,22 +385,29 @@ impl RelQueryVar {
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum ClauseType {
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     Parameter,
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     FirstSubQuery,
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     SubQuery,
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     Query,
 }
 
 #[derive(Default)]
 pub(crate) struct SuffixGenerator {
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     seed: i32,
 }
 
 impl SuffixGenerator {
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     pub(crate) fn new() -> SuffixGenerator {
         SuffixGenerator { seed: -1 }
     }
 
+    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
     pub(crate) fn suffix(&mut self) -> String {
         self.seed += 1;
         "_".to_string() + &self.seed.to_string()

--- a/src/engine/database/mod.rs
+++ b/src/engine/database/mod.rs
@@ -118,12 +118,16 @@ pub trait DatabaseEndpoint {
 pub(crate) trait Transaction {
     fn begin(&mut self) -> Result<(), Error>;
 
+    fn query_start() -> String;
     #[allow(clippy::too_many_arguments)]
     fn node_create_query<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
         query: String,
+        rel_create_fragments: Vec<String>,
         params: HashMap<String, Value>,
+        node_var: &str,
         label: &str,
+        return_clause: ReturnClause,
         partition_key_opt: Option<&Value>,
         props: HashMap<String, Value>,
         info: &Info,
@@ -152,6 +156,7 @@ pub(crate) trait Transaction {
         rel_name: &str,
         props: HashMap<String, Value>,
         props_type_name: Option<&str>,
+        return_clause: ReturnClause,
         partition_key_opt: Option<&Value>,
         info: &Info,
         sg: &mut SuffixGenerator,
@@ -180,9 +185,10 @@ pub(crate) trait Transaction {
         rel_query_fragments: Vec<String>,
         params: HashMap<String, Value>,
         label: &str,
-        node_suffix: &str,
+        node_var: &str,
+        name_node: bool,
         union_type: bool,
-        return_node: Option<&str>,
+        return_clause: ReturnClause,
         param_suffix: &str,
         props: HashMap<String, Value>,
     ) -> Result<(String, HashMap<String, Value>), Error>;
@@ -208,7 +214,8 @@ pub(crate) trait Transaction {
         dst_var: &str,
         dst_suffix: &str,
         dst_query_opt: Option<String>,
-        return_rel: bool,
+        top_level_query: bool,
+        return_clause: ReturnClause,
         props: HashMap<String, Value>,
         sg: &mut SuffixGenerator,
     ) -> Result<(String, HashMap<String, Value>), Error>;
@@ -226,8 +233,8 @@ pub(crate) trait Transaction {
         &mut self,
         query: String,
         params: HashMap<String, Value>,
-        node_suffix: &str,
-        ids: Vec<Value>,
+        label: &str,
+        node_var: &str,
         props: HashMap<String, Value>,
         partition_key_opt: Option<&Value>,
         info: &Info,
@@ -254,6 +261,7 @@ pub(crate) trait Transaction {
         rel_suffix: &str,
         rel_var: &str,
         dst_suffix: &str,
+        top_level_query: bool,
         props: HashMap<String, Value>,
         props_type_name: Option<&str>,
         partition_key_opt: Option<&Value>,
@@ -318,6 +326,13 @@ pub(crate) trait Transaction {
     fn commit(&mut self) -> Result<(), Error>;
 
     fn rollback(&mut self) -> Result<(), Error>;
+}
+
+#[derive(Debug)]
+pub(crate) enum ReturnClause {
+    None,
+    SubQuery(String),
+    Query(String),
 }
 
 #[derive(Default)]

--- a/src/engine/database/mod.rs
+++ b/src/engine/database/mod.rs
@@ -285,6 +285,7 @@ pub(crate) trait Transaction {
         &mut self,
         match_query: String,
         params: HashMap<String, Value>,
+        src_var: &str,
         src_label: &str,
         src_suffix: &str,
         rel_name: &str,

--- a/src/engine/database/mod.rs
+++ b/src/engine/database/mod.rs
@@ -122,7 +122,6 @@ pub(crate) trait Transaction {
     #[allow(clippy::too_many_arguments)]
     fn node_create_query<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
-        query: String,
         rel_create_fragments: Vec<String>,
         params: HashMap<String, Value>,
         node_var: &str,
@@ -146,7 +145,7 @@ pub(crate) trait Transaction {
     #[allow(clippy::too_many_arguments)]
     fn rel_create_query<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
-        src_query: String,
+        src_query: Option<String>,
         params: HashMap<String, Value>,
         src_var: &str,
         dst_query: &str,
@@ -179,10 +178,24 @@ pub(crate) trait Transaction {
     ) -> Result<Vec<Rel<GlobalCtx, RequestCtx>>, Error>;
 
     #[allow(clippy::too_many_arguments)]
+    fn node_read_fragment(
+        &mut self,
+        rel_query_fragments: Vec<(String, String)>,
+        params: HashMap<String, Value>,
+        label: &str,
+        node_var: &str,
+        name_node: bool,
+        union_type: bool,
+        param_suffix: &str,
+        props: HashMap<String, Value>,
+        return_clause: ReturnClause,
+    ) -> Result<(String, String, HashMap<String, Value>), Error>;
+
+    #[allow(clippy::too_many_arguments)]
     fn node_read_query(
         &mut self,
-        query: String,
-        rel_query_fragments: Vec<String>,
+        match_fragment: &str,
+        where_fragment: &str,
         params: HashMap<String, Value>,
         label: &str,
         node_var: &str,
@@ -202,18 +215,34 @@ pub(crate) trait Transaction {
     ) -> Result<Vec<Node<GlobalCtx, RequestCtx>>, Error>;
 
     #[allow(clippy::too_many_arguments)]
-    fn rel_read_query(
+    fn rel_read_fragment(
         &mut self,
-        query: String,
         params: HashMap<String, Value>,
         src_label: &str,
         src_var: &str,
-        src_query: Option<String>,
+        src_query: Option<(String, String)>,
         rel_name: &str,
         rel_suffix: &str,
         dst_var: &str,
         dst_suffix: &str,
-        dst_query_opt: Option<String>,
+        dst_query_opt: Option<(String, String)>,
+        top_level_query: bool,
+        props: HashMap<String, Value>,
+        sg: &mut SuffixGenerator,
+    ) -> Result<(String, String, HashMap<String, Value>), Error>;
+
+    #[allow(clippy::too_many_arguments)]
+    fn rel_read_query(
+        &mut self,
+        match_fragment: &str,
+        where_fragment: &str,
+        params: HashMap<String, Value>,
+        src_label: &str,
+        src_var: &str,
+        rel_name: &str,
+        rel_suffix: &str,
+        dst_var: &str,
+        dst_suffix: &str,
         top_level_query: bool,
         return_clause: ReturnClause,
         props: HashMap<String, Value>,
@@ -254,7 +283,7 @@ pub(crate) trait Transaction {
     #[allow(clippy::too_many_arguments)]
     fn rel_update_query<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
-        query: String,
+        match_query: String,
         params: HashMap<String, Value>,
         src_label: &str,
         src_suffix: &str,
@@ -284,7 +313,8 @@ pub(crate) trait Transaction {
     #[allow(clippy::too_many_arguments)]
     fn node_delete_query(
         &mut self,
-        query: String,
+        match_query: String,
+        rel_delete_fragments: Vec<String>,
         params: HashMap<String, Value>,
         node_var: &str,
         label: &str,
@@ -303,7 +333,9 @@ pub(crate) trait Transaction {
     #[allow(clippy::too_many_arguments)]
     fn rel_delete_query(
         &mut self,
-        query: String,
+        match_query: String,
+        src_delete_query_opt: Option<String>,
+        dst_delete_query_opt: Option<String>,
         params: HashMap<String, Value>,
         src_label: &str,
         rel_name: &str,

--- a/src/engine/database/mod.rs
+++ b/src/engine/database/mod.rs
@@ -138,126 +138,83 @@ pub(crate) trait Transaction {
 
     fn rel_create_fragment<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
-        src_query_opt: Option<String>,
+        dst_query: &str,
         params: HashMap<String, Value>,
         rel_var: &RelQueryVar,
-        dst_query: &str,
         props: HashMap<String, Value>,
-        props_type_name: Option<&str>,
         clause: ClauseType,
-        partition_key_opt: Option<&Value>,
-        info: &Info,
         sg: &mut SuffixGenerator,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
-    #[allow(clippy::too_many_arguments)]
     fn rel_create_query<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
         src_query_opt: Option<String>,
         rel_create_fragments: Vec<String>,
-        src_var: &str,
-        src_label: &str,
-        rel_vars: Vec<String>,
-        dst_vars: Vec<String>,
         params: HashMap<String, Value>,
-        sg: &mut SuffixGenerator,
+        rel_vars: Vec<RelQueryVar>,
         clause: ClauseType,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
-    #[allow(clippy::too_many_arguments)]
     fn create_rels<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
         query: String,
         params: HashMap<String, Value>,
-        src_label: &str,
-        src_ids: Vec<Value>,
-        dst_label: &str,
-        dst_ids: Vec<Value>,
-        rel_name: &str,
-        props: HashMap<String, Value>,
         props_type_name: Option<&str>,
         partition_key_opt: Option<&Value>,
-        info: &Info,
     ) -> Result<Vec<Rel<GlobalCtx, RequestCtx>>, Error>;
 
-    #[allow(clippy::too_many_arguments)]
     fn node_read_fragment(
         &mut self,
         rel_query_fragments: Vec<(String, String)>,
         params: HashMap<String, Value>,
-        label: &str,
-        node_var: &str,
-        name_node: bool,
-        union_type: bool,
-        param_suffix: &str,
+        node_var: &NodeQueryVar,
         props: HashMap<String, Value>,
         clause: ClauseType,
+        sg: &mut SuffixGenerator,
     ) -> Result<(String, String, HashMap<String, Value>), Error>;
 
-    #[allow(clippy::too_many_arguments)]
     fn node_read_query(
         &mut self,
         match_fragment: &str,
         where_fragment: &str,
         params: HashMap<String, Value>,
-        label: &str,
-        node_var: &str,
-        name_node: bool,
-        union_type: bool,
+        node_var: &NodeQueryVar,
         clause: ClauseType,
-        param_suffix: &str,
-        props: HashMap<String, Value>,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
     fn read_nodes<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
         query: String,
-        partition_key_opt: Option<&Value>,
         params: Option<HashMap<String, Value>>,
+        partition_key_opt: Option<&Value>,
         info: &Info,
     ) -> Result<Vec<Node<GlobalCtx, RequestCtx>>, Error>;
 
-    #[allow(clippy::too_many_arguments)]
     fn rel_read_fragment(
         &mut self,
-        params: HashMap<String, Value>,
-        src_label: &str,
-        src_var: &str,
-        src_query: Option<(String, String)>,
-        rel_name: &str,
-        rel_suffix: &str,
-        dst_var: &str,
-        dst_suffix: &str,
+        src_query_opt: Option<(String, String)>,
         dst_query_opt: Option<(String, String)>,
-        top_level_query: bool,
+        params: HashMap<String, Value>,
+        rel_var: &RelQueryVar,
         props: HashMap<String, Value>,
         sg: &mut SuffixGenerator,
     ) -> Result<(String, String, HashMap<String, Value>), Error>;
 
-    #[allow(clippy::too_many_arguments)]
     fn rel_read_query(
         &mut self,
         match_fragment: &str,
         where_fragment: &str,
         params: HashMap<String, Value>,
-        src_label: &str,
-        src_var: &str,
-        rel_name: &str,
-        rel_suffix: &str,
-        dst_var: &str,
-        dst_suffix: &str,
-        top_level_query: bool,
+        rel_var: &RelQueryVar,
         clause: ClauseType,
-        props: HashMap<String, Value>,
-        sg: &mut SuffixGenerator,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
     fn read_rels<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
         query: String,
+        params: Option<HashMap<String, Value>>,
         props_type_name: Option<&str>,
         partition_key_opt: Option<&Value>,
-        params: Option<HashMap<String, Value>>,
     ) -> Result<Vec<Rel<GlobalCtx, RequestCtx>>, Error>;
 
     #[allow(clippy::too_many_arguments)]
@@ -266,75 +223,52 @@ pub(crate) trait Transaction {
         match_query: String,
         change_queries: Vec<String>,
         params: HashMap<String, Value>,
-        label: &str,
-        node_var: &str,
+        node_var: &NodeQueryVar,
         props: HashMap<String, Value>,
-        partition_key_opt: Option<&Value>,
-        info: &Info,
-        sg: &mut SuffixGenerator,
         clause: ClauseType,
+        sg: &mut SuffixGenerator,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
     fn update_nodes<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
         query: String,
         params: HashMap<String, Value>,
-        label: &str,
         partition_key_opt: Option<&Value>,
         info: &Info,
     ) -> Result<Vec<Node<GlobalCtx, RequestCtx>>, Error>;
 
-    #[allow(clippy::too_many_arguments)]
     fn rel_update_query<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
         match_query: String,
         params: HashMap<String, Value>,
-        src_var: &str,
-        src_label: &str,
-        src_suffix: &str,
-        rel_name: &str,
-        rel_suffix: &str,
-        rel_var: &str,
-        dst_suffix: &str,
-        top_level_query: bool,
+        rel_var: &RelQueryVar,
         props: HashMap<String, Value>,
-        props_type_name: Option<&str>,
-        partition_key_opt: Option<&Value>,
-        sg: &mut SuffixGenerator,
         clause: ClauseType,
+        sg: &mut SuffixGenerator,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
-    #[allow(clippy::too_many_arguments)]
     fn update_rels<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
         query: String,
         params: HashMap<String, Value>,
-        src_label: &str,
-        rel_name: &str,
-        rel_ids: Vec<Value>,
         props_type_name: Option<&str>,
         partition_key_opt: Option<&Value>,
     ) -> Result<Vec<Rel<GlobalCtx, RequestCtx>>, Error>;
 
-    #[allow(clippy::too_many_arguments)]
     fn node_delete_query(
         &mut self,
         match_query: String,
         rel_delete_fragments: Vec<String>,
         params: HashMap<String, Value>,
-        node_var: &str,
-        label: &str,
-        partition_key_opt: Option<&Value>,
-        sg: &mut SuffixGenerator,
-        top_level_query: bool,
+        node_var: &NodeQueryVar,
         clause: ClauseType,
+        sg: &mut SuffixGenerator,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
     fn delete_nodes(
         &mut self,
         query: String,
         params: HashMap<String, Value>,
-        label: &str,
         partition_key_opt: Option<&Value>,
     ) -> Result<i32, Error>;
 
@@ -345,21 +279,15 @@ pub(crate) trait Transaction {
         src_delete_query_opt: Option<String>,
         dst_delete_query_opt: Option<String>,
         params: HashMap<String, Value>,
-        src_label: &str,
-        rel_name: &str,
-        rel_suffix: &str,
-        partition_key_opt: Option<&Value>,
-        sg: &mut SuffixGenerator,
-        top_level_query: bool,
+        rel_var: &RelQueryVar,
         clause: ClauseType,
+        sg: &mut SuffixGenerator,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
     fn delete_rels(
         &mut self,
         query: String,
         params: HashMap<String, Value>,
-        src_label: &str,
-        rel_name: &str,
         partition_key_opt: Option<&Value>,
     ) -> Result<i32, Error>;
 
@@ -369,33 +297,33 @@ pub(crate) trait Transaction {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct NodeQueryVar<'a> {
-    base: &'a str,
-    suffix: &'a str,
-    label: Option<&'a str>,
+pub(crate) struct NodeQueryVar {
+    base: String,
+    suffix: String,
+    label: Option<String>,
     name: String,
 }
 
-impl<'a> NodeQueryVar<'a> {
-    pub(crate) fn new(label: Option<&'a str>, base: &'a str, suffix: &'a str) -> NodeQueryVar<'a> {
+impl NodeQueryVar {
+    pub(crate) fn new(label: Option<String>, base: String, suffix: String) -> NodeQueryVar {
         NodeQueryVar {
-            base,
-            suffix,
+            base: base.clone(),
+            suffix: suffix.clone(),
             label,
-            name: base.to_string() + suffix,
+            name: base + &suffix,
         }
     }
 
     pub(crate) fn base(&self) -> &str {
-        self.base
+        &self.base
     }
 
     pub(crate) fn label(&self) -> Result<&str, Error> {
-        self.label.ok_or_else(|| Error::LabelNotFound)
+        self.label.as_deref().ok_or_else(|| Error::LabelNotFound)
     }
 
     pub(crate) fn suffix(&self) -> &str {
-        self.suffix
+        &self.suffix
     }
 
     pub(crate) fn name(&self) -> &str {
@@ -404,36 +332,32 @@ impl<'a> NodeQueryVar<'a> {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct RelQueryVar<'a> {
-    label: &'a str,
-    suffix: &'a str,
+pub(crate) struct RelQueryVar {
+    label: String,
+    suffix: String,
     name: String,
-    src: &'a NodeQueryVar<'a>,
-    dst: &'a NodeQueryVar<'a>,
+    src: NodeQueryVar,
+    dst: NodeQueryVar,
 }
 
-impl<'a> RelQueryVar<'a> {
+impl RelQueryVar {
     pub(crate) fn new(
-        label: &'a str,
-        suffix: &'a str,
-        src: &'a NodeQueryVar<'a>,
-        dst: &'a NodeQueryVar<'a>,
-    ) -> RelQueryVar<'a> {
+        label: String,
+        suffix: String,
+        src: NodeQueryVar,
+        dst: NodeQueryVar,
+    ) -> RelQueryVar {
         RelQueryVar {
             label,
-            suffix,
-            name: "rel".to_string() + suffix,
+            suffix: suffix.clone(),
+            name: "rel".to_string() + &suffix,
             src,
             dst,
         }
     }
 
     pub(crate) fn label(&self) -> &str {
-        self.label
-    }
-
-    pub(crate) fn suffix(&self) -> &str {
-        self.suffix
+        &self.label
     }
 
     pub(crate) fn name(&self) -> &str {
@@ -441,15 +365,15 @@ impl<'a> RelQueryVar<'a> {
     }
 
     pub(crate) fn src(&self) -> &NodeQueryVar {
-        self.src
+        &self.src
     }
 
     pub(crate) fn dst(&self) -> &NodeQueryVar {
-        self.dst
+        &self.dst
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 pub(crate) enum ClauseType {
     Parameter,
     FirstSubQuery,

--- a/src/engine/database/mod.rs
+++ b/src/engine/database/mod.rs
@@ -320,6 +320,7 @@ pub(crate) trait Transaction {
         label: &str,
         partition_key_opt: Option<&Value>,
         sg: &mut SuffixGenerator,
+        top_level_query: bool,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
     fn delete_nodes(
@@ -342,6 +343,7 @@ pub(crate) trait Transaction {
         rel_suffix: &str,
         partition_key_opt: Option<&Value>,
         sg: &mut SuffixGenerator,
+        top_level_query: bool,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
     fn delete_rels(

--- a/src/engine/database/mod.rs
+++ b/src/engine/database/mod.rs
@@ -231,7 +231,8 @@ pub(crate) trait Transaction {
     #[allow(clippy::too_many_arguments)]
     fn node_update_query<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
-        query: String,
+        match_query: String,
+        change_queries: Vec<String>,
         params: HashMap<String, Value>,
         label: &str,
         node_var: &str,
@@ -287,7 +288,6 @@ pub(crate) trait Transaction {
         params: HashMap<String, Value>,
         node_var: &str,
         label: &str,
-        ids: Vec<Value>,
         partition_key_opt: Option<&Value>,
         sg: &mut SuffixGenerator,
     ) -> Result<(String, HashMap<String, Value>), Error>;
@@ -297,7 +297,6 @@ pub(crate) trait Transaction {
         query: String,
         params: HashMap<String, Value>,
         label: &str,
-        ids: Vec<Value>,
         partition_key_opt: Option<&Value>,
     ) -> Result<i32, Error>;
 
@@ -319,7 +318,6 @@ pub(crate) trait Transaction {
         params: HashMap<String, Value>,
         src_label: &str,
         rel_name: &str,
-        rel_ids: Vec<Value>,
         partition_key_opt: Option<&Value>,
     ) -> Result<i32, Error>;
 

--- a/src/engine/database/mod.rs
+++ b/src/engine/database/mod.rs
@@ -118,18 +118,14 @@ pub trait DatabaseEndpoint {
 pub(crate) trait Transaction {
     fn begin(&mut self) -> Result<(), Error>;
 
-    fn query_start() -> String;
-    #[allow(clippy::too_many_arguments)]
     fn node_create_query<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
         rel_create_fragments: Vec<String>,
         params: HashMap<String, Value>,
         node_var: &str,
-        label: &str,
-        clause: ClauseType,
-        partition_key_opt: Option<&Value>,
+        node_label: &str,
         props: HashMap<String, Value>,
-        info: &Info,
+        clause: ClauseType,
         sg: &mut SuffixGenerator,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
@@ -173,6 +169,7 @@ pub(crate) trait Transaction {
         dst_vars: Vec<String>,
         params: HashMap<String, Value>,
         sg: &mut SuffixGenerator,
+        clause: ClauseType,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
     #[allow(clippy::too_many_arguments)]
@@ -283,6 +280,7 @@ pub(crate) trait Transaction {
         partition_key_opt: Option<&Value>,
         info: &Info,
         sg: &mut SuffixGenerator,
+        clause: ClauseType,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
     fn update_nodes<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
@@ -311,6 +309,7 @@ pub(crate) trait Transaction {
         props_type_name: Option<&str>,
         partition_key_opt: Option<&Value>,
         sg: &mut SuffixGenerator,
+        clause: ClauseType,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
     #[allow(clippy::too_many_arguments)]
@@ -336,6 +335,7 @@ pub(crate) trait Transaction {
         partition_key_opt: Option<&Value>,
         sg: &mut SuffixGenerator,
         top_level_query: bool,
+        clause: ClauseType,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
     fn delete_nodes(
@@ -359,6 +359,7 @@ pub(crate) trait Transaction {
         partition_key_opt: Option<&Value>,
         sg: &mut SuffixGenerator,
         top_level_query: bool,
+        clause: ClauseType,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
     fn delete_rels(
@@ -380,7 +381,7 @@ pub(crate) enum ClauseType {
     Parameter(String),
     FirstSubQuery(String),
     SubQuery(String),
-    Query(String),
+    Query,
 }
 
 #[derive(Default)]

--- a/src/engine/database/mod.rs
+++ b/src/engine/database/mod.rs
@@ -126,7 +126,7 @@ pub(crate) trait Transaction {
         params: HashMap<String, Value>,
         node_var: &str,
         label: &str,
-        return_clause: ReturnClause,
+        clause: ClauseType,
         partition_key_opt: Option<&Value>,
         props: HashMap<String, Value>,
         info: &Info,
@@ -143,7 +143,7 @@ pub(crate) trait Transaction {
     ) -> Result<Node<GlobalCtx, RequestCtx>, Error>;
 
     #[allow(clippy::too_many_arguments)]
-    fn rel_create_query<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
+    fn rel_create_fragment<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
         src_query: Option<String>,
         params: HashMap<String, Value>,
@@ -152,12 +152,26 @@ pub(crate) trait Transaction {
         src_label: &str,
         dst_label: &str,
         dst_var: &str,
+        rel_var: &str,
         rel_name: &str,
         props: HashMap<String, Value>,
         props_type_name: Option<&str>,
-        return_clause: ReturnClause,
+        clause: ClauseType,
         partition_key_opt: Option<&Value>,
         info: &Info,
+        sg: &mut SuffixGenerator,
+    ) -> Result<(String, HashMap<String, Value>), Error>;
+
+    #[allow(clippy::too_many_arguments)]
+    fn rel_create_query<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
+        &mut self,
+        src_query_opt: Option<String>,
+        rel_create_fragments: Vec<String>,
+        src_var: &str,
+        src_label: &str,
+        rel_vars: Vec<String>,
+        dst_vars: Vec<String>,
+        params: HashMap<String, Value>,
         sg: &mut SuffixGenerator,
     ) -> Result<(String, HashMap<String, Value>), Error>;
 
@@ -188,7 +202,7 @@ pub(crate) trait Transaction {
         union_type: bool,
         param_suffix: &str,
         props: HashMap<String, Value>,
-        return_clause: ReturnClause,
+        clause: ClauseType,
     ) -> Result<(String, String, HashMap<String, Value>), Error>;
 
     #[allow(clippy::too_many_arguments)]
@@ -201,7 +215,7 @@ pub(crate) trait Transaction {
         node_var: &str,
         name_node: bool,
         union_type: bool,
-        return_clause: ReturnClause,
+        clause: ClauseType,
         param_suffix: &str,
         props: HashMap<String, Value>,
     ) -> Result<(String, HashMap<String, Value>), Error>;
@@ -244,7 +258,7 @@ pub(crate) trait Transaction {
         dst_var: &str,
         dst_suffix: &str,
         top_level_query: bool,
-        return_clause: ReturnClause,
+        clause: ClauseType,
         props: HashMap<String, Value>,
         sg: &mut SuffixGenerator,
     ) -> Result<(String, HashMap<String, Value>), Error>;
@@ -361,9 +375,10 @@ pub(crate) trait Transaction {
     fn rollback(&mut self) -> Result<(), Error>;
 }
 
-#[derive(Debug)]
-pub(crate) enum ReturnClause {
-    None,
+#[derive(Clone, Debug)]
+pub(crate) enum ClauseType {
+    Parameter(String),
+    FirstSubQuery(String),
     SubQuery(String),
     Query(String),
 }

--- a/src/engine/database/neo4j.rs
+++ b/src/engine/database/neo4j.rs
@@ -961,6 +961,7 @@ impl Transaction for Neo4jTransaction<'_> {
         label: &str,
         _partition_key_opt: Option<&Value>,
         sg: &mut SuffixGenerator,
+        _top_level_query: bool,
     ) -> Result<(String, HashMap<String, Value>), Error> {
         trace!(
             "Neo4jTransaction::node_delete_query called -- match_query: {}, params: {:#?}, node_var: {}, label: {}",
@@ -1024,7 +1025,8 @@ impl Transaction for Neo4jTransaction<'_> {
         rel_name: &str,
         rel_suffix: &str,
         _partition_key_opt: Option<&Value>,
-        _sg: &mut SuffixGenerator,
+        sg: &mut SuffixGenerator,
+        _top_level_query: bool,
     ) -> Result<(String, HashMap<String, Value>), Error> {
         trace!("Neo4jTransaction::rel_delete_query called -- params: {:#?}, src_label: {}, rel_name: {}, rel_suffix: {:#?}", 
         params, src_label, rel_name, rel_suffix);
@@ -1037,7 +1039,13 @@ impl Transaction for Neo4jTransaction<'_> {
             query.push_str(&("CALL {\n".to_string() + &ddq + "}\n"));
         }
 
-        let query = query + "DELETE rel" + rel_suffix + "\n" + "RETURN count(*) as count\n";
+        let query = query
+            + "DELETE rel"
+            + rel_suffix
+            + "\n"
+            + "RETURN count(*) as count"
+            + &sg.suffix()
+            + "\n";
 
         Ok((query, params))
     }

--- a/src/engine/database/neo4j.rs
+++ b/src/engine/database/neo4j.rs
@@ -866,9 +866,9 @@ impl TryFrom<HashMap<String, bolt_proto::value::Value>> for Value {
     type Error = Error;
 
     fn try_from(hm: HashMap<String, bolt_proto::value::Value>) -> Result<Value, Error> {
-        let hmv: HashMap<String, Value> = hm.into_iter().try_fold (
+        let hmv: HashMap<String, Value> = hm.into_iter().try_fold(
             HashMap::new(),
-            |mut acc, (key, bolt_value)| -> Result<HashMap<String, Value>,Error> {
+            |mut acc, (key, bolt_value)| -> Result<HashMap<String, Value>, Error> {
                 let value = Value::try_from(bolt_value)?;
                 acc.insert(key, value);
                 Ok(acc)

--- a/src/engine/database/neo4j.rs
+++ b/src/engine/database/neo4j.rs
@@ -857,7 +857,7 @@ impl Transaction for Neo4jTransaction<'_> {
         if !change_queries.is_empty() {
             query.push_str(&("WITH ".to_string() + node_var + "\n"));
             for cq in change_queries.iter() {
-                query.push_str(&("CALL {\nWITH ".to_string() + node_var + "\n" + cq + "\n}\n"));
+                query.push_str(&("CALL {\nWITH ".to_string() + node_var + "\n" + cq + "}\n"));
             }
         }
         query = Neo4jTransaction::add_node_return(query, node_var, "node");
@@ -897,8 +897,9 @@ impl Transaction for Neo4jTransaction<'_> {
         &mut self,
         query: String,
         mut params: HashMap<String, Value>,
+        src_var: &str,
         src_label: &str,
-        src_suffix: &str,
+        _src_suffix: &str,
         rel_name: &str,
         rel_suffix: &str,
         rel_var: &str,
@@ -917,7 +918,7 @@ impl Transaction for Neo4jTransaction<'_> {
         let mut query = query + "SET " + rel_var + " += $" + &props_var + "\n";
         query = Neo4jTransaction::add_rel_return(
             query,
-            &("src".to_string() + src_suffix),
+            src_var,
             &("rel".to_string() + rel_suffix),
             &("dst".to_string() + dst_suffix),
         );

--- a/src/engine/objects/mod.rs
+++ b/src/engine/objects/mod.rs
@@ -677,6 +677,10 @@ where
             _rctx: PhantomData,
         }
     }
+
+    pub(crate) fn id(&self) -> &Value {
+        &self.id
+    }
 }
 
 impl<GlobalCtx, RequestCtx> GraphQLType for Rel<GlobalCtx, RequestCtx>

--- a/src/engine/objects/mod.rs
+++ b/src/engine/objects/mod.rs
@@ -617,20 +617,6 @@ pub(crate) enum NodeRef<GlobalCtx: GlobalContext, RequestCtx: RequestContext> {
     Node(Node<GlobalCtx, RequestCtx>),
 }
 
-impl<GlobalCtx, RequestCtx> NodeRef<GlobalCtx, RequestCtx>
-where
-    GlobalCtx: GlobalContext,
-    RequestCtx: RequestContext,
-{
-    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
-    pub(crate) fn id(&self) -> Result<&Value, Error> {
-        match self {
-            NodeRef::Identifier { id, label: _ } => Ok(&id),
-            NodeRef::Node(n) => n.id(),
-        }
-    }
-}
-
 /// Represents a relationship in the graph data structure for auto-generated CRUD operations and
 /// custom resolvers.
 ///
@@ -690,21 +676,6 @@ where
             _gctx: PhantomData,
             _rctx: PhantomData,
         }
-    }
-
-    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
-    fn dst_id(&self) -> Result<&Value, Error> {
-        self.dst_ref.id()
-    }
-
-    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
-    fn id(&self) -> &Value {
-        &self.id
-    }
-
-    #[cfg(any(feature = "cosmos", feature = "neo4j"))]
-    fn src_id(&self) -> Result<&Value, Error> {
-        self.src_ref.id()
     }
 }
 

--- a/src/engine/objects/resolvers/mod.rs
+++ b/src/engine/objects/resolvers/mod.rs
@@ -4,16 +4,17 @@ use crate::engine::context::{GlobalContext, GraphQLContext, RequestContext};
 use crate::engine::database::cosmos::CosmosTransaction;
 #[cfg(feature = "neo4j")]
 use crate::engine::database::neo4j::Neo4jTransaction;
+use crate::engine::database::DatabasePool;
 #[cfg(any(feature = "cosmos", feature = "neo4j"))]
-use crate::engine::database::{ClauseType, Transaction};
-use crate::engine::database::{DatabasePool, NodeQueryVar, RelQueryVar, SuffixGenerator};
+use crate::engine::database::{
+    ClauseType, NodeQueryVar, RelQueryVar, SuffixGenerator, Transaction,
+};
 use crate::engine::resolvers::Object;
 use crate::engine::resolvers::ResolverFacade;
 use crate::engine::resolvers::{Arguments, ExecutionResult, Executor};
 use crate::engine::schema::Info;
 use crate::engine::value::Value;
 use crate::error::Error;
-#[cfg(any(feature = "cosmos", feature = "neo4j"))]
 use log::trace;
 use std::collections::HashMap;
 use std::convert::TryInto;

--- a/src/engine/objects/resolvers/mod.rs
+++ b/src/engine/objects/resolvers/mod.rs
@@ -761,6 +761,7 @@ impl<'r> Resolver<'r> {
             input.value,
             transaction,
             &mut sg,
+            true,
         )?;
         let query = T::query_start() + &query;
         let results =

--- a/src/engine/objects/resolvers/mod.rs
+++ b/src/engine/objects/resolvers/mod.rs
@@ -307,7 +307,7 @@ impl<'r> Resolver<'r> {
 
         transaction.begin()?;
         let (query, params) = visit_node_delete_input::<T, GlobalCtx, RequestCtx>(
-            String::new(),
+            T::query_start(),
             HashMap::new(),
             label,
             &("node".to_string() + &suffix),
@@ -317,8 +317,7 @@ impl<'r> Resolver<'r> {
             transaction,
             &mut sg,
         )?;
-        let results =
-            transaction.delete_nodes(query, params, label, Vec::new(), self.partition_key_opt);
+        let results = transaction.delete_nodes(query, params, label, self.partition_key_opt);
 
         if results.is_ok() {
             transaction.commit()?;
@@ -753,14 +752,8 @@ impl<'r> Resolver<'r> {
             transaction,
             &mut sg,
         )?;
-        let results = transaction.delete_rels(
-            query,
-            params,
-            src_label,
-            rel_name,
-            Vec::new(),
-            self.partition_key_opt,
-        );
+        let results =
+            transaction.delete_rels(query, params, src_label, rel_name, self.partition_key_opt);
 
         if results.is_ok() {
             transaction.commit()?;

--- a/src/engine/objects/resolvers/mod.rs
+++ b/src/engine/objects/resolvers/mod.rs
@@ -783,17 +783,15 @@ impl<'r> Resolver<'r> {
     pub(super) fn resolve_rel_read_query<GlobalCtx: GlobalContext, RequestCtx: RequestContext>(
         &mut self,
         field_name: &str,
-        src_ids_opt: Option<Vec<Value>>,
         rel_name: &str,
         info: &Info,
         input_opt: Option<Input<GlobalCtx, RequestCtx>>,
         executor: &Executor<GraphQLContext<GlobalCtx, RequestCtx>>,
     ) -> ExecutionResult {
         trace!(
-        "Resolver::resolve_rel_read_query called -- info.name: {:#?}, field_name: {}, src_ids: {:#?}, rel_name: {}, partition_key_opt: {:#?}, input_opt: {:#?}",
+        "Resolver::resolve_rel_read_query called -- info.name: {:#?}, field_name: {}, rel_name: {}, partition_key_opt: {:#?}, input_opt: {:#?}",
         info.name(),
         field_name,
-        src_ids_opt,
         rel_name,
         self.partition_key_opt,
         input_opt
@@ -807,7 +805,6 @@ impl<'r> Resolver<'r> {
             #[cfg(feature = "cosmos")]
             DatabasePool::Cosmos(c) => self.resolve_rel_read_query_with_transaction(
                 field_name,
-                src_ids_opt,
                 rel_name,
                 info,
                 input_opt,
@@ -818,7 +815,6 @@ impl<'r> Resolver<'r> {
                 let c = runtime.block_on(p.get())?;
                 self.resolve_rel_read_query_with_transaction(
                     field_name,
-                    src_ids_opt,
                     rel_name,
                     info,
                     input_opt,
@@ -850,7 +846,6 @@ impl<'r> Resolver<'r> {
     pub(super) fn resolve_rel_read_query_with_transaction<GlobalCtx, RequestCtx, T>(
         &mut self,
         field_name: &str,
-        src_ids_opt: Option<Vec<Value>>,
         rel_name: &str,
         info: &Info,
         input_opt: Option<Input<GlobalCtx, RequestCtx>>,
@@ -862,10 +857,9 @@ impl<'r> Resolver<'r> {
         T: Transaction,
     {
         trace!(
-        "Resolver::resolve_rel_read_query called -- info.name: {:#?}, field_name: {}, src_ids: {:#?}, rel_name: {}, partition_key_opt: {:#?}, input_opt: {:#?}",
+        "Resolver::resolve_rel_read_query called -- info.name: {:#?}, field_name: {}, rel_name: {}, partition_key_opt: {:#?}, input_opt: {:#?}",
         info.name(),
         field_name,
-        src_ids_opt,
         rel_name,
         self.partition_key_opt,
         input_opt
@@ -889,7 +883,7 @@ impl<'r> Resolver<'r> {
         let (query, params) = visit_rel_query_input(
             &src_prop.type_name(),
             &src_suffix,
-            src_ids_opt,
+            None,
             rel_name,
             &dst_prop.type_name(),
             &dst_suffix,

--- a/src/engine/objects/resolvers/mod.rs
+++ b/src/engine/objects/resolvers/mod.rs
@@ -210,7 +210,7 @@ impl<'r> Resolver<'r> {
             HashMap::new(),
             &node_var,
             &p.type_name(),
-            ClauseType::Query(node_var.clone()),
+            ClauseType::Query,
             &Info::new(itd.type_name().to_owned(), info.type_defs()),
             self.partition_key_opt,
             input.value,
@@ -218,7 +218,6 @@ impl<'r> Resolver<'r> {
             transaction,
             &mut sg,
         )?;
-        let query = T::query_start() + &query;
         let results =
             transaction.create_node(query, params, &p.type_name(), self.partition_key_opt, info);
 
@@ -316,7 +315,6 @@ impl<'r> Resolver<'r> {
             transaction,
             &mut sg,
         )?;
-        let query = T::query_start() + &query;
         let results = transaction.delete_nodes(query, params, label, self.partition_key_opt);
 
         if results.is_ok() {
@@ -418,7 +416,7 @@ impl<'r> Resolver<'r> {
             &node_var,
             true,
             false,
-            ClauseType::Query(node_var.to_string()),
+            ClauseType::Query,
             &Info::new(itd.type_name().to_owned(), info.type_defs()),
             self.partition_key_opt,
             input_opt.map(|i| i.value),
@@ -433,11 +431,10 @@ impl<'r> Resolver<'r> {
             &node_var,
             true,
             false,
-            ClauseType::Query(node_var.to_string()),
+            ClauseType::Query,
             &sg.suffix(),
             HashMap::new(),
         )?;
-        let query = T::query_start() + &query;
         let results = transaction.read_nodes(query, self.partition_key_opt, Some(params), info);
 
         if info.name() == "Mutation" || info.name() == "Query" {
@@ -536,7 +533,6 @@ impl<'r> Resolver<'r> {
             transaction,
             &mut sg,
         )?;
-        let query = T::query_start() + &query;
         let result =
             transaction.update_nodes(query, params, &p.type_name(), self.partition_key_opt, info);
 
@@ -656,7 +652,6 @@ impl<'r> Resolver<'r> {
             transaction,
             &mut sg,
         )?;
-        let query = T::query_start() + &query;
         let result = transaction.create_rels(
             query,
             params,
@@ -763,7 +758,6 @@ impl<'r> Resolver<'r> {
             &mut sg,
             true,
         )?;
-        let query = T::query_start() + &query;
         let results =
             transaction.delete_rels(query, params, src_label, rel_name, self.partition_key_opt);
 
@@ -915,7 +909,7 @@ impl<'r> Resolver<'r> {
             &rel_suffix,
             &dst_var,
             &dst_suffix,
-            ClauseType::Query(rel_name.to_string()),
+            ClauseType::Query,
             true,
             &Info::new(itd.type_name().to_owned(), info.type_defs()),
             self.partition_key_opt,
@@ -934,11 +928,10 @@ impl<'r> Resolver<'r> {
             &dst_var,
             &dst_suffix,
             true,
-            ClauseType::Query(rel_name.to_string()),
+            ClauseType::Query,
             HashMap::new(),
             &mut sg,
         )?;
-        let query = T::query_start() + &query;
         let results = transaction.read_rels(
             query,
             Some(p.type_name()),
@@ -1055,7 +1048,6 @@ impl<'r> Resolver<'r> {
             transaction,
             &mut sg,
         )?;
-        let query = T::query_start() + &query;
         let results = transaction.update_rels(
             query,
             params,
@@ -1241,7 +1233,7 @@ impl<'r> Resolver<'r> {
                     false,
                     "",
                     props.clone(),
-                    ClauseType::Query(node_var.to_string()),
+                    ClauseType::Query,
                 )?;
                 let (query, params) = transaction.node_read_query(
                     &match_fragment,
@@ -1251,11 +1243,10 @@ impl<'r> Resolver<'r> {
                     &node_var,
                     true,
                     false,
-                    ClauseType::Query(node_var.to_string()),
+                    ClauseType::Query,
                     "",
                     props,
                 )?;
-                let query = T::query_start() + &query;
                 transaction.read_nodes(query, self.partition_key_opt, Some(params), info)
             }
             _ => Err(Error::SchemaItemNotFound {

--- a/src/engine/objects/resolvers/visitors.rs
+++ b/src/engine/objects/resolvers/visitors.rs
@@ -218,6 +218,7 @@ where
             })?),
             transaction,
             sg,
+            true,
         )
     } else {
         Err(Error::TypeNotExpected)
@@ -235,6 +236,7 @@ fn visit_node_delete_mutation_input<T, GlobalCtx, RequestCtx>(
     input: Option<Value>,
     transaction: &mut T,
     sg: &mut SuffixGenerator,
+    top_level_query: bool,
 ) -> Result<(String, HashMap<String, Value>), Error>
 where
     GlobalCtx: GlobalContext,
@@ -272,6 +274,7 @@ where
                                         val,
                                         transaction,
                                         sg,
+                                        false
                                     )?;
                                     queries.push(query);
                                     Ok((queries, params))
@@ -288,6 +291,7 @@ where
                                 v,
                                 transaction,
                                 sg,
+                                false
                             )?;
 
                             queries.push(query);
@@ -309,6 +313,7 @@ where
         label,
         partition_key_opt,
         sg,
+        top_level_query,
     )
 }
 
@@ -788,6 +793,7 @@ where
                 v,
                 transaction,
                 sg,
+                false,
             )
         } else if let Some(v) = m.remove("UPDATE") {
             // Using remove to take ownership
@@ -1025,6 +1031,7 @@ pub(super) fn visit_rel_delete_input<T, GlobalCtx, RequestCtx>(
     input: Value,
     transaction: &mut T,
     sg: &mut SuffixGenerator,
+    top_level_query: bool,
 ) -> Result<(String, HashMap<String, Value>), Error>
 where
     GlobalCtx: GlobalContext,
@@ -1135,6 +1142,7 @@ where
             &rel_suffix,
             partition_key_opt,
             sg,
+            top_level_query,
         )
     } else {
         Err(Error::TypeNotExpected)
@@ -1183,6 +1191,7 @@ where
             Some(v),
             transaction,
             sg,
+            false,
         )
     } else {
         Err(Error::TypeNotExpected)
@@ -1493,6 +1502,7 @@ where
             Some(v),
             transaction,
             sg,
+            false,
         )
     } else {
         Err(Error::TypeNotExpected)

--- a/src/error.rs
+++ b/src/error.rs
@@ -83,6 +83,12 @@ pub enum Error {
     /// missing an expected field.
     InputItemNotFound { name: String },
 
+    /// Returned if an internal CRUD handler tries to retrieve the label for a node or relationship
+    /// from an internal temporary bookkeeping structure and is unable to do so. This likely
+    /// indicates an internal bug. Thus, if you happen to see it, please open an issue at the
+    /// Warpgrapher project.
+    LabelNotFound,
+
     /// Returned if a Neo4J query fails to execute correctly
     #[cfg(feature = "neo4j")]
     Neo4jQueryFailed {
@@ -229,6 +235,9 @@ impl Display for Error {
             Error::InputItemNotFound { name } => {
                 write!(f, "Could not find an expected argument, {}, in the GraphQL query.", name)
             }
+            Error::LabelNotFound => {
+                write!(f, "Could not find a label for a destination node.")
+            }
             #[cfg(feature = "neo4j")]
             Error::Neo4jPoolNotBuilt { source } => {
                 write!(f, "Could not build database connection pool for Neo4J. Source error: {}.", source)
@@ -308,6 +317,7 @@ impl std::error::Error for Error {
             Error::EnvironmentVariableNotParsed { source } => Some(source),
             Error::ExtensionFailed { source } => Some(source.as_ref()),
             Error::InputItemNotFound { name: _ } => None,
+            Error::LabelNotFound => None,
             #[cfg(feature = "neo4j")]
             Error::Neo4jPoolNotBuilt { source } => Some(source),
             #[cfg(feature = "neo4j")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,9 +84,9 @@ pub enum Error {
     InputItemNotFound { name: String },
 
     /// Returned if an internal CRUD handler tries to retrieve the label for a node or relationship
-    /// from an internal temporary bookkeeping structure and is unable to do so. This likely
-    /// indicates an internal bug. Thus, if you happen to see it, please open an issue at the
-    /// Warpgrapher project.
+    /// from an internal temporary bookkeeping structure and is unable to do so. This almost
+    /// certainly indicates an internal bug. Thus, if you happen to see it, please open an issue at
+    /// the Warpgrapher project.
     LabelNotFound,
 
     /// Returned if a Neo4J query fails to execute correctly

--- a/tests/node_resolver_test.rs
+++ b/tests/node_resolver_test.rs
@@ -612,15 +612,6 @@ async fn error_on_node_missing_id(mut client: Client<AppGlobalCtx, AppRequestCtx
 
     assert!(pu.is_null());
 
-    let pd = client
-        .delete_node(
-            "Project",
-            Some("1234"),
-            Some(&json!({"name": "Project One"})),
-            None,
-        )
-        .await
-        .unwrap();
-
-    assert!(pd.is_null());
+    // No error thrown for deletion of nodes, because the node ID isn't accessed during deletion.
+    // Therefore, there is no delete_node test here.
 }

--- a/tests/node_snst_resolver_test.rs
+++ b/tests/node_snst_resolver_test.rs
@@ -712,7 +712,13 @@ async fn update_snst_node_with_new_rel(mut client: Client<AppGlobalCtx, AppReque
         .unwrap();
 
     // Cannot add a rel to a single-node rel slot that's already filled.
-    assert_eq!(projects, serde_json::value::Value::Null);
+    assert_eq!(
+        projects.as_array().unwrap()[0]
+            .get("owner")
+            .unwrap()
+            .clone(),
+        serde_json::value::Value::Null
+    );
 
     let users = client
         .read_node(
@@ -846,7 +852,10 @@ async fn update_snst_node_with_existing_rel(mut client: Client<AppGlobalCtx, App
         .await
         .unwrap();
 
-    assert_eq!(pu, serde_json::value::Value::Null);
+    assert_eq!(
+        pu.as_array().unwrap()[0].get("owner").unwrap().clone(),
+        serde_json::value::Value::Null
+    );
 
     let users = client
         .read_node(

--- a/tests/setup/mod.rs
+++ b/tests/setup/mod.rs
@@ -488,7 +488,7 @@ pub(crate) fn project_top_dev(
         }
 
         let dev_id = if let bolt_proto::value::Value::Node(n) =
-            &records.iter().next().expect("Expected result").fields()[0]
+            &records.get(0).expect("Expected result").fields()[0]
         {
             Value::try_from(n.properties().get("id").expect("Expected id").clone())
                 .expect("Expected string")
@@ -534,7 +534,7 @@ pub(crate) fn project_top_issues(
         }
 
         let bug_id = if let bolt_proto::value::Value::Node(n) =
-            &records.iter().next().expect("Expected result").fields()[0]
+            &records.get(0).expect("Expected result").fields()[0]
         {
             Value::try_from(n.properties().get("id").expect("Expected id").clone())
                 .expect("Expected string")
@@ -555,7 +555,7 @@ pub(crate) fn project_top_issues(
         }
 
         let feature_id = if let bolt_proto::value::Value::Node(n) =
-            &records.iter().next().expect("Expected result").fields()[0]
+            &records.get(0).expect("Expected result").fields()[0]
         {
             Value::try_from(n.properties().get("id").expect("Expected id").clone())
                 .expect("Expected string")


### PR DESCRIPTION
Refactors resolvers, visitors, and database code to move mutations into a single query, making them transactions across a broader selection of databases.