### PR TITLE
Property hiding

### DIFF
--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -766,7 +766,7 @@ pub struct Property {
     /// Filter of properties that determines whether the property will be used in creation,
     /// matching/query, update, and output/shape portions of the schema
     #[serde(default)]
-    uses_filter: UsesFilter,
+    uses: UsesFilter,
 
     /// The name of the type of the property (e.g. String)
     #[serde(rename = "type")]
@@ -817,7 +817,7 @@ impl Property {
     /// ```
     pub fn new(
         name: String,
-        uses_filter: UsesFilter,
+        uses: UsesFilter,
         type_name: String,
         required: bool,
         list: bool,
@@ -826,7 +826,7 @@ impl Property {
     ) -> Property {
         Property {
             name,
-            uses_filter,
+            uses,
             type_name,
             required,
             list,
@@ -874,9 +874,9 @@ impl Property {
     /// let p = Property::new("propname".to_string(), UsesFilter::all(), "String".to_string(),
     ///         true, false, None, None);
     ///
-    /// assert_eq!(UsesFilter::all(), p.uses_filter());
-    pub fn uses_filter(&self) -> UsesFilter {
-        self.uses_filter
+    /// assert_eq!(UsesFilter::all(), p.uses());
+    pub fn uses(&self) -> UsesFilter {
+        self.uses
     }
 
     /// Returns the optional name of the custom resolver associated with this property

--- a/src/engine/config.rs
+++ b/src/engine/config.rs
@@ -752,9 +752,10 @@ pub enum GraphqlType {
 /// # Examples
 ///
 /// ```rust
-/// # use warpgrapher::engine::config::Property;
+/// # use warpgrapher::engine::config::{Property, UsesFilter};
 ///
-/// let p = Property::new("name".to_string(), false, "String".to_string(), true, false, None, None);
+/// let p = Property::new("name".to_string(), UsesFilter::all(), "String".to_string(), true,
+/// false, None, None);
 /// ```
 #[derive(Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -762,9 +763,10 @@ pub struct Property {
     /// Name of the property
     name: String,
 
-    /// If true, removes this property from the schema and hides it from the public API
-    #[serde(default = "get_false")]
-    hidden: bool,
+    /// Filter of properties that determines whether the property will be used in creation,
+    /// matching/query, update, and output/shape portions of the schema
+    #[serde(default)]
+    uses_filter: UsesFilter,
 
     /// The name of the type of the property (e.g. String)
     #[serde(rename = "type")]
@@ -808,13 +810,14 @@ impl Property {
     /// # Examples
     ///
     /// ```rust
-    /// # use warpgrapher::engine::config::Property;
+    /// # use warpgrapher::engine::config::{Property, UsesFilter};
     ///
-    /// let p = Property::new("name".to_string(), false, "String".to_string(), true, false, None, None);
+    /// let p = Property::new("name".to_string(), UsesFilter::all(), "String".to_string(), true,
+    /// false, None, None);
     /// ```
     pub fn new(
         name: String,
-        hidden: bool,
+        uses_filter: UsesFilter,
         type_name: String,
         required: bool,
         list: bool,
@@ -823,7 +826,7 @@ impl Property {
     ) -> Property {
         Property {
             name,
-            hidden,
+            uses_filter,
             type_name,
             required,
             list,
@@ -840,7 +843,8 @@ impl Property {
     ///
     /// # use warpgrapher::engine::config::Property;
     ///
-    /// let p = Property::new("name".to_string(), "String".to_string(), true, false, None, None);
+    /// let p = Property::new("name".to_string(), UsesFiter::all(), "String".to_string(),
+    ///         true, false, None, None);
     ///
     /// assert!(!p.list());
     pub fn list(&self) -> bool {
@@ -853,16 +857,26 @@ impl Property {
     ///
     /// # use warpgrapher::engine::config::Property;
     ///
-    /// let p = Property::new("propname".to_string(), "String".to_string(), true, false, None,
-    ///     None);
+    /// let p = Property::new("propname".to_string(), UsesFilter::all(), "String".to_string(),
+    ///     true, false, None, None);
     ///
     /// assert_eq!("propname", p.name());
     pub fn name(&self) -> &str {
         &self.name
     }
 
-    pub fn hidden(&self) -> bool {
-        self.hidden
+    /// Returns the filter describing how a property is to be used
+    ///
+    /// # Examples
+    ///
+    /// # use warpgrapher::engine::config::Property;
+    ///
+    /// let p = Property::new("propname".to_string(), UsesFilter::all(), "String".to_string(),
+    ///         true, false, None, None);
+    ///
+    /// assert_eq!(UsesFilter::all(), p.uses_filter());
+    pub fn uses_filter(&self) -> UsesFilter {
+        self.uses_filter
     }
 
     /// Returns the optional name of the custom resolver associated with this property
@@ -1125,12 +1139,14 @@ impl Relationship {
 /// # Examples
 ///
 /// ```rust
-/// # use warpgrapher::engine::config::{Type, Property, EndpointsFilter};
+/// # use warpgrapher::engine::config::{Type, Property, EndpointsFilter, UsesFilter};
 ///
 /// let t = Type::new(
 ///     "User".to_string(),
-///     vec!(Property::new("name".to_string(), false, "String".to_string(), true, false, None, None),
-///          Property::new("role".to_string(), false, "String".to_string(), true, false, None, None)),
+///     vec!(Property::new("name".to_string(), UsesFilter::all(), "String".to_string(),
+///         true, false, None, None),
+///          Property::new("role".to_string(), UsesFilter::all(), "String".to_string(),
+///         true, false, None, None)),
 ///     vec!(),
 ///     EndpointsFilter::all()
 /// );
@@ -1174,12 +1190,14 @@ impl Type {
     /// # Examples
     ///
     /// ```rust
-    /// # use warpgrapher::engine::config::{Type, Property, EndpointsFilter};
+    /// # use warpgrapher::engine::config::{Type, Property, EndpointsFilter, UsesFilter};
     ///
     /// let t = Type::new(
     ///     "User".to_string(),
-    ///     vec!(Property::new("name".to_string(), false, "String".to_string(), true, false, None, None),
-    ///          Property::new("role".to_string(), false, "String".to_string(), true, false, None, None)),
+    ///     vec!(Property::new("name".to_string(), UsesFilter::all(), "String".to_string(),
+    ///         true, false, None, None),
+    ///          Property::new("role".to_string(), UsesFilter::all(), "String".to_string(),
+    ///         true, false, None, None)),
     ///     vec!(),
     ///     EndpointsFilter::all()
     /// );
@@ -1204,12 +1222,12 @@ impl Type {
     /// # Examples
     ///
     /// ```rust
-    /// # use warpgrapher::engine::config::{Type, Property, EndpointsFilter};
+    /// # use warpgrapher::engine::config::{Type, Property, EndpointsFilter, UsesFilter};
     ///
     /// let t = Type::new(
     ///     "User".to_string(),
-    ///     vec!(Property::new("name".to_string(), false, "String".to_string(), true, false, None, None),
-    ///          Property::new("role".to_string(), false, "String".to_string(), true, false, None, None)),
+    ///     vec!(Property::new("name".to_string(), UsesFilter::all(), "String".to_string(), true, false, None, None),
+    ///          Property::new("role".to_string(), UsesFilter::all(), "String".to_string(), true, false, None, None)),
     ///     vec!(),
     ///     EndpointsFilter::all()
     /// );
@@ -1228,12 +1246,12 @@ impl Type {
     /// # Examples
     ///
     /// ```rust
-    /// # use warpgrapher::engine::config::{Type, Property, EndpointsFilter};
+    /// # use warpgrapher::engine::config::{Type, Property, EndpointsFilter, UsesFilter};
     ///
     /// let t = Type::new(
     ///     "User".to_string(),
-    ///     vec!(Property::new("name".to_string(), false, "String".to_string(), true, false, None, None),
-    ///          Property::new("role".to_string(), false, "String".to_string(), true, false, None, None)),
+    ///     vec!(Property::new("name".to_string(), UsesFilter::all(), "String".to_string(), true, false, None, None),
+    ///          Property::new("role".to_string(), UsesFilter::all(), "String".to_string(), true, false, None, None)),
     ///     vec!(),
     ///     EndpointsFilter::all()
     /// );
@@ -1251,14 +1269,12 @@ impl Type {
     /// # Examples
     ///
     /// ```rust
-    /// # use warpgrapher::engine::config::{Type, Property, EndpointsFilter};
+    /// # use warpgrapher::engine::config::{Type, Property, EndpointsFilter, UsesFilter};
     ///
     /// let t = Type::new(
     ///     "User".to_string(),
-    ///     vec!(Property::new("name".to_string(), false, "String".to_string(), true, false, None, None)),
-    ///     vec!(),
-    ///     EndpointsFilter::all()
-    /// );
+    ///     vec!(Property::new("name".to_string(), UsesFilter::all(), "String".to_string(),
+    ///         true, false, None, None)), vec!(), EndpointsFilter::all());
     ///
     /// assert_eq!("name", t.props().next().expect("Expected property").name());
     /// ```
@@ -1277,11 +1293,11 @@ impl Type {
     /// # Examples
     ///
     /// ```rust
-    /// # use warpgrapher::engine::config::{Type, Property, EndpointsFilter};
+    /// # use warpgrapher::engine::config::{Type, Property, EndpointsFilter, UsesFilter};
     ///
     /// let t = Type::new(
     ///     "User".to_string(),
-    ///     vec!(Property::new("name".to_string(), false, "String".to_string(), true, false, None, None)),
+    ///     vec!(Property::new("name".to_string(), UsesFilter::all(), "String".to_string(), true, false, None, None)),
     ///     vec!(),
     ///     EndpointsFilter::all()
     /// );
@@ -1300,13 +1316,15 @@ impl Type {
     /// # Examples
     ///
     /// ```rust
-    /// # use warpgrapher::engine::config::{EndpointsFilter, Property, Relationship, Type};
+    /// # use warpgrapher::engine::config::{EndpointsFilter, Property, Relationship,
+    /// #    Type, UsesFilter};
     ///
     /// let t = Type::new(
     ///     "User".to_string(),
-    ///     vec!(Property::new("name".to_string(), false, "String".to_string(), true, false, None, None)),
+    ///     vec!(Property::new("name".to_string(), UsesFilter::all(), "String".to_string(), true,
+    ///         false, None, None)),
     ///     vec!(Relationship::new("rel_name".to_string(), false, vec!("Role".to_string()), vec!(
-    ///         Property::new("rel_prop".to_string(), false, "String".to_string(), true, false, None, None)
+    ///         Property::new("rel_prop".to_string(), UsesFilter::all(), "String".to_string(), true, false, None, None)
     ///     ), EndpointsFilter::all(), None)),
     ///     EndpointsFilter::all()
     /// );
@@ -1376,6 +1394,166 @@ pub enum TypeDef {
     Custom(Type),
 }
 
+/// Configuration item for property usage filters. This allows configuration to control which of the
+/// basic creation input, query input, update input, and output uses are auto-generated for a
+/// [`Property`]. If a filter boolean is set to true, the use of the property is generated. False
+/// indicates that the property should be omitted from use. For example, one might set the output
+/// use to true and all other uses to false for calculated value that is derived upon request but
+/// would never appear in the creation or update of a node. If all are set to false, the property
+/// is hidden, meaning that it can be read from and written to the database but does not appear in
+/// the client-facing GraphQL schema.
+///
+/// [`Property`]: ./struct.Property.html
+///
+/// # Examples
+///
+/// ```rust
+/// # use warpgrapher::engine::config::UsesFilter;
+///
+/// let uf = UsesFilter::new(true, true, true, true);
+/// ```
+#[derive(Copy, Clone, Debug, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+pub struct UsesFilter {
+    /// True if the property should be included in the NodeCreateMutationInput portion of the schema
+    #[serde(default = "get_true")]
+    create: bool,
+
+    /// True if the property should be included in the NodeQueryInput portion of the schema
+    #[serde(default = "get_true")]
+    query: bool,
+
+    /// True if the property should be included in the NodeUpdateMutationInput portion of the schema
+    #[serde(default = "get_true")]
+    update: bool,
+
+    /// True if the property should be included in output shape portion of the schema
+    #[serde(default = "get_true")]
+    output: bool,
+}
+
+impl UsesFilter {
+    /// Creates a new filter with the option to configure uses of a property
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use warpgrapher::engine::config::UsesFilter;
+    ///
+    /// let uf = UsesFilter::new(false, false, false, true);
+    /// ```
+    pub fn new(create: bool, query: bool, update: bool, output: bool) -> UsesFilter {
+        UsesFilter {
+            create,
+            query,
+            update,
+            output,
+        }
+    }
+
+    /// Creates a new filter with all uses -- create, query, update, and output
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use warpgrapher::engine::config::UsesFilter;
+    ///
+    /// let uf = UsesFilter::all();
+    /// ```
+    pub fn all() -> UsesFilter {
+        UsesFilter {
+            create: true,
+            query: true,
+            update: true,
+            output: true,
+        }
+    }
+
+    /// Returns true if Warpgrapher should use the property in the NodeCreateMutationInput
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use warpgrapher::engine::config::UsesFilter;
+    ///
+    /// let uf = UsesFilter::all();
+    /// assert_eq!(true, uf.create());
+    /// ```
+    pub fn create(self) -> bool {
+        self.create
+    }
+
+    /// Returns true if Warpgrapher should use the property in the NodeQueryInput
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use warpgrapher::engine::config::UsesFilter;
+    ///
+    /// let uf = UsesFilter::all();
+    /// assert_eq!(true, uf.query());
+    /// ```
+    pub fn query(self) -> bool {
+        self.query
+    }
+
+    /// Creates a new filter with no uses of a property, hiding it from the GraphQL schema
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use warpgrapher::engine::config::UsesFilter;
+    ///
+    /// let uf = UsesFilter::none();
+    /// ```
+    pub fn none() -> UsesFilter {
+        UsesFilter {
+            create: false,
+            query: false,
+            update: false,
+            output: false,
+        }
+    }
+
+    /// Returns true if Warpgrapher should generate a property in the output shape of a node
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use warpgrapher::engine::config::UsesFilter;
+    ///
+    /// let uf = UsesFilter::all();
+    /// assert_eq!(true, uf.output());
+    /// ```
+    pub fn output(self) -> bool {
+        self.output
+    }
+
+    /// Returns true if Warpgrapher should use the property in the NodeUpdateInput
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use warpgrapher::engine::config::UsesFilter;
+    ///
+    /// let uf = UsesFilter::all();
+    /// assert_eq!(true, uf.update());
+    /// ```
+    pub fn update(self) -> bool {
+        self.update
+    }
+}
+
+impl Default for UsesFilter {
+    fn default() -> UsesFilter {
+        UsesFilter {
+            create: true,
+            query: true,
+            update: true,
+            output: true,
+        }
+    }
+}
+
 /// Creates a combined [`Configuration`] data structure from multiple [`Configuration`] structs.
 /// All [`Configuration`] structs must be the same version.
 ///
@@ -1443,7 +1621,7 @@ pub(crate) fn mock_project_type() -> Type {
         vec![
             Property::new(
                 "name".to_string(),
-                false,
+                UsesFilter::all(),
                 "String".to_string(),
                 true,
                 false,
@@ -1452,7 +1630,7 @@ pub(crate) fn mock_project_type() -> Type {
             ),
             Property::new(
                 "tags".to_string(),
-                false,
+                UsesFilter::all(),
                 "String".to_string(),
                 false,
                 true,
@@ -1461,7 +1639,7 @@ pub(crate) fn mock_project_type() -> Type {
             ),
             Property::new(
                 "public".to_string(),
-                false,
+                UsesFilter::all(),
                 "Boolean".to_string(),
                 true,
                 false,
@@ -1476,7 +1654,7 @@ pub(crate) fn mock_project_type() -> Type {
                 vec!["User".to_string()],
                 vec![Property::new(
                     "since".to_string(),
-                    false,
+                    UsesFilter::all(),
                     "String".to_string(),
                     false,
                     false,
@@ -1521,7 +1699,7 @@ fn mock_user_type() -> Type {
         "User".to_string(),
         vec![Property::new(
             "name".to_string(),
-            false,
+            UsesFilter::all(),
             "String".to_string(),
             true,
             false,
@@ -1539,7 +1717,7 @@ fn mock_kanbanboard_type() -> Type {
         "KanbanBoard".to_string(),
         vec![Property::new(
             "name".to_string(),
-            false,
+            UsesFilter::all(),
             "String".to_string(),
             true,
             false,
@@ -1557,7 +1735,7 @@ fn mock_scrumboard_type() -> Type {
         "ScrumBoard".to_string(),
         vec![Property::new(
             "name".to_string(),
-            false,
+            UsesFilter::all(),
             "String".to_string(),
             true,
             false,
@@ -1575,7 +1753,7 @@ fn mock_feature_type() -> Type {
         "Feature".to_string(),
         vec![Property::new(
             "name".to_string(),
-            false,
+            UsesFilter::all(),
             "String".to_string(),
             true,
             false,
@@ -1593,7 +1771,7 @@ fn mock_bug_type() -> Type {
         "Bug".to_string(),
         vec![Property::new(
             "name".to_string(),
-            false,
+            UsesFilter::all(),
             "String".to_string(),
             true,
             false,
@@ -1611,7 +1789,7 @@ fn mock_commit_type() -> Type {
         "Commit".to_string(),
         vec![Property::new(
             "name".to_string(),
-            false,
+            UsesFilter::all(),
             "String".to_string(),
             true,
             false,
@@ -1664,7 +1842,7 @@ pub(crate) fn mock_endpoint_three() -> Endpoint {
                 "BurndownFilter".to_string(),
                 vec![Property::new(
                     "ticket_types".to_string(),
-                    false,
+                    UsesFilter::all(),
                     "String".to_string(),
                     true,
                     false,
@@ -1682,7 +1860,7 @@ pub(crate) fn mock_endpoint_three() -> Endpoint {
                 "BurndownMetrics".to_string(),
                 vec![Property::new(
                     "points".to_string(),
-                    false,
+                    UsesFilter::all(),
                     "Int".to_string(),
                     false,
                     false,
@@ -1727,7 +1905,7 @@ pub(crate) fn mock_endpoints_filter() -> Configuration {
             "User".to_string(),
             vec![Property::new(
                 "name".to_string(),
-                false,
+                UsesFilter::all(),
                 "String".to_string(),
                 true,
                 false,
@@ -1745,7 +1923,7 @@ pub(crate) fn mock_endpoints_filter() -> Configuration {
 mod tests {
     use super::{
         compose, Configuration, Endpoint, EndpointType, EndpointsFilter, Property, Relationship,
-        Type,
+        Type, UsesFilter,
     };
     use crate::Error;
     use std::convert::TryInto;
@@ -1766,7 +1944,7 @@ mod tests {
                     vec![
                         Property::new(
                             "username".to_string(),
-                            false,
+                            UsesFilter::all(),
                             "String".to_string(),
                             false,
                             false,
@@ -1775,7 +1953,7 @@ mod tests {
                         ),
                         Property::new(
                             "email".to_string(),
-                            false,
+                            UsesFilter::all(),
                             "String".to_string(),
                             false,
                             false,
@@ -1791,7 +1969,7 @@ mod tests {
                     "Team".to_string(),
                     vec![Property::new(
                         "teamname".to_string(),
-                        false,
+                        UsesFilter::all(),
                         "String".to_string(),
                         false,
                         false,
@@ -1829,7 +2007,7 @@ mod tests {
     fn new_property() {
         let p = Property::new(
             "name".to_string(),
-            false,
+            UsesFilter::all(),
             "String".to_string(),
             true,
             false,
@@ -1849,7 +2027,7 @@ mod tests {
             vec![
                 Property::new(
                     "name".to_string(),
-                    false,
+                    UsesFilter::all(),
                     "String".to_string(),
                     true,
                     false,
@@ -1858,7 +2036,7 @@ mod tests {
                 ),
                 Property::new(
                     "role".to_string(),
-                    false,
+                    UsesFilter::all(),
                     "String".to_string(),
                     true,
                     false,

--- a/src/engine/database/gremlin.rs
+++ b/src/engine/database/gremlin.rs
@@ -390,7 +390,9 @@ impl GremlinTransaction {
         } else if let Some(GValue::Int64(i)) = results.get(0) {
             Ok(i32::try_from(*i)?)
         } else {
-            Err(Error::TypeNotExpected { details: Some("extract_count value is not GValue Int32 or Int64".to_string()) })
+            Err(Error::TypeNotExpected {
+                details: Some("extract_count value is not GValue Int32 or Int64".to_string()),
+            })
         }
     }
 
@@ -426,7 +428,9 @@ impl GremlinTransaction {
                 } else if let GKey::String(k) = key {
                     Ok((k, val.try_into()?))
                 } else {
-                    Err(Error::TypeNotExpected { details: Some("GValue is not String or List".to_string()) })
+                    Err(Error::TypeNotExpected {
+                        details: Some("GValue is not String or List".to_string()),
+                    })
                 }
             })
             .collect::<Result<HashMap<String, Value>, Error>>()
@@ -437,11 +441,15 @@ impl GremlinTransaction {
             map.into_iter()
                 .map(|(k, v)| match (k, v) {
                     (GKey::String(s), v) => Ok((s, v)),
-                    (_, _) => Err(Error::TypeNotExpected { details: Some("GValue is not String".to_string()) }),
+                    (_, _) => Err(Error::TypeNotExpected {
+                        details: Some("GValue is not String".to_string()),
+                    }),
                 })
                 .collect()
         } else {
-            Err(Error::TypeNotExpected { details: Some("GValue is not Map".to_string()) })
+            Err(Error::TypeNotExpected {
+                details: Some("GValue is not Map".to_string()),
+            })
         }
     }
 
@@ -548,7 +556,9 @@ impl GremlinTransaction {
                             if let GKey::String(k) = key {
                                 Ok((k, val.try_into()?))
                             } else {
-                                Err(Error::TypeNotExpected { details: Some("GKey is not String".to_string()) })
+                                Err(Error::TypeNotExpected {
+                                    details: Some("GKey is not String".to_string()),
+                                })
                             }
                         })
                         .collect::<Result<HashMap<String, Value>, Error>>()?;
@@ -582,7 +592,11 @@ impl Transaction for GremlinTransaction {
         Ok(())
     }
 
-    #[tracing::instrument(level="info", name="wg-gremlin-execute-query", skip(self, query, params))]
+    #[tracing::instrument(
+        level = "info",
+        name = "wg-gremlin-execute-query",
+        skip(self, query, params)
+    )]
     async fn execute_query<RequestCtx: RequestContext>(
         &mut self,
         query: String,
@@ -612,7 +626,7 @@ impl Transaction for GremlinTransaction {
     }
 
     #[tracing::instrument(
-        level="info",
+        level = "info",
         name = "wg-gremlin-create-nodes",
         skip(self, node_var, props, partition_key_opt, info, sg)
     )]
@@ -671,7 +685,7 @@ impl Transaction for GremlinTransaction {
     }
 
     #[tracing::instrument(
-        level="info",
+        level = "info",
         name = "wg-gremlin-create-rels",
         skip(
             self,
@@ -912,7 +926,7 @@ impl Transaction for GremlinTransaction {
     }
 
     #[tracing::instrument(
-        level="info",
+        level = "info",
         name = "wg-gremlin-read-nodes",
         skip(self, _node_var, query_fragment, partition_key_opt, info)
     )]
@@ -974,7 +988,7 @@ impl Transaction for GremlinTransaction {
         let mut params = HashMap::new();
 
         if self.bindings {
-            query.push_str(&(".hasId(within(id_list))"));
+            query.push_str(".hasId(within(id_list))");
 
             let ids = rels
                 .iter()
@@ -1106,7 +1120,7 @@ impl Transaction for GremlinTransaction {
     }
 
     #[tracing::instrument(
-        level="info",
+        level = "info",
         name = "wg-gremlin-read-rels",
         skip(self, query_fragment, rel_var, props_type_name, partition_key_opt)
     )]
@@ -1150,7 +1164,7 @@ impl Transaction for GremlinTransaction {
     }
 
     #[tracing::instrument(
-        level="info",
+        level = "info",
         name = "wg-gremlin-update-nodes",
         skip(self, query_fragment, node_var, props, partition_key_opt, info, sg)
     )]
@@ -1202,7 +1216,7 @@ impl Transaction for GremlinTransaction {
     }
 
     #[tracing::instrument(
-        level="info",
+        level = "info",
         name = "wg-gremlin-update-rels",
         skip(
             self,
@@ -1266,7 +1280,7 @@ impl Transaction for GremlinTransaction {
     }
 
     #[tracing::instrument(
-        level="info",
+        level = "info",
         name = "wg-gremlin-delete-nodes",
         skip(self, query_fragment, node_var, partition_key_opt)
     )]
@@ -1310,7 +1324,7 @@ impl Transaction for GremlinTransaction {
     }
 
     #[tracing::instrument(
-        level="info",
+        level = "info",
         name = "wg-gremlin-delete-rels",
         skip(self, query_fragment, rel_var, partition_key_opt)
     )]

--- a/src/engine/database/neo4j.rs
+++ b/src/engine/database/neo4j.rs
@@ -1138,7 +1138,7 @@ impl<RequestCtx: RequestContext> TryFrom<bolt_proto::value::Value> for Node<Requ
         match value {
             bolt_proto::value::Value::Node(n) => {
                 let type_name = &n.labels()[0];
-                let properties: &HashMap<String, bolt_proto::value::Value> = &n.properties();
+                let properties: &HashMap<String, bolt_proto::value::Value> = n.properties();
                 let props_value = Value::try_from(properties.clone())?;
                 let props = HashMap::<String, Value>::try_from(props_value)?;
                 Ok(Node::new(type_name.to_string(), props))

--- a/src/engine/events.rs
+++ b/src/engine/events.rs
@@ -28,14 +28,14 @@ use std::convert::TryInto;
 ///
 /// ```rust
 /// # use warpgrapher::Error;
-/// # use warpgrapher::engine::config::{Configuration, Property};
+/// # use warpgrapher::engine::config::{Configuration, Property, UsesFilter};
 ///
 /// fn before_engine_build_func(config: &mut Configuration) -> Result<(), Error> {
 ///     for t in config.model.iter_mut() {
 ///         let mut_props: &mut Vec<Property> = t.mut_props();
 ///         mut_props.push(Property::new(
 ///             "global_prop".to_string(),
-///             false,
+///             UsesFilter::all(),
 ///             "String".to_string(),
 ///             false,
 ///             false,
@@ -1220,7 +1220,10 @@ where
                 src: "".to_string(),
                 dst: "".to_string(),
             })?,
-            &Info::new(format!("{}CreateMutationInput", type_name.to_string()), self.info.type_defs()),
+            &Info::new(
+                format!("{}CreateMutationInput", type_name.to_string()),
+                self.info.type_defs(),
+            ),
             partition_key_opt,
             &mut sg,
             self.transaction,

--- a/src/engine/objects/mod.rs
+++ b/src/engine/objects/mod.rs
@@ -61,7 +61,7 @@ where
     RequestCtx: RequestContext,
 {
     fn name(info: &Self::TypeInfo) -> Option<&str> {
-        Some(&info.name())
+        Some(info.name())
     }
 
     fn meta<'r>(info: &Self::TypeInfo, registry: &mut Registry<'r>) -> MetaType<'r>
@@ -138,7 +138,7 @@ where
     type TypeInfo = Info;
 
     fn type_name<'i>(&self, info: &'i Self::TypeInfo) -> Option<&'i str> {
-        Some(&info.name())
+        Some(info.name())
     }
 }
 
@@ -215,10 +215,7 @@ where
             "__label".to_string(),
             Value::String(self.concrete_typename.clone()),
         );
-        fields.insert(
-            "id".to_string(),
-            self.id()?.clone(),
-        );
+        fields.insert("id".to_string(), self.id()?.clone());
         let m = Value::Map(fields);
         let v = serde_json::Value::try_from(m)?;
         let t: T = serde_json::from_value(v)
@@ -400,7 +397,12 @@ where
                             ))
                         }
                         (_, _, _) => {
-                            panic!("{}", Error::TypeNotExpected { details: Some("argument is not valid".to_string()) })
+                            panic!(
+                                "{}",
+                                Error::TypeNotExpected {
+                                    details: Some("argument is not valid".to_string())
+                                }
+                            )
                         }
                     }
                 })
@@ -422,7 +424,7 @@ where
     RequestCtx: RequestContext,
 {
     fn name(info: &Self::TypeInfo) -> Option<&str> {
-        Some(&info.name())
+        Some(info.name())
     }
 
     fn meta<'r>(info: &Self::TypeInfo, registry: &mut Registry<'r>) -> MetaType<'r>
@@ -430,7 +432,7 @@ where
         DefaultScalarValue: 'r,
     {
         trace!("Node::meta called -- info.name: {}", info.name());
-        let nt = info.type_def_by_name(&info.name()).unwrap_or_else(|e| {
+        let nt = info.type_def_by_name(info.name()).unwrap_or_else(|e| {
             error!("Node::meta panicking on type: {}", info.name().to_string());
             panic!("{}", e)
         });
@@ -449,12 +451,12 @@ where
     type Context = GraphQLContext<RequestCtx>;
     type TypeInfo = Info;
     fn type_name<'i>(&self, info: &'i Self::TypeInfo) -> Option<&'i str> {
-        Some(&info.name())
+        Some(info.name())
     }
 
     fn concrete_type_name(&self, _context: &Self::Context, info: &Self::TypeInfo) -> String {
         let tn = info
-            .type_def_by_name(&info.name())
+            .type_def_by_name(info.name())
             .unwrap_or_else(|e| {
                 error!(
                     "Node::concrete_type_name panicking on type: {}",
@@ -539,7 +541,7 @@ where
                     resolver
                         .resolve_custom_rel(
                             info,
-                            &rel_name,
+                            rel_name,
                             p.resolver(),
                             Object::Node(self),
                             args,
@@ -547,7 +549,10 @@ where
                         )
                         .await
                 }
-                PropertyKind::Input => Err((Error::TypeNotExpected { details: Some("PropertyKind::Input not expected".to_string()) }).into()),
+                PropertyKind::Input => Err((Error::TypeNotExpected {
+                    details: Some("PropertyKind::Input not expected".to_string()),
+                })
+                .into()),
                 PropertyKind::NodeCreateMutation => {
                     let input = input_opt.ok_or_else(|| Error::InputItemNotFound {
                         name: "input".to_string(),
@@ -561,7 +566,7 @@ where
                         name: "input".to_string(),
                     })?;
                     resolver
-                        .resolve_node_delete_mutation(field_name, &label, info, input, executor)
+                        .resolve_node_delete_mutation(field_name, label, info, input, executor)
                         .await
                 }
                 PropertyKind::NodeUpdateMutation => {
@@ -594,7 +599,7 @@ where
                         }
                     };
                     resolver
-                        .resolve_rel_read_query(field_name, &rel_name, info, io, executor)
+                        .resolve_rel_read_query(field_name, rel_name, info, io, executor)
                         .await
                 }
                 PropertyKind::RelCreateMutation {
@@ -606,7 +611,7 @@ where
                     })?;
                     resolver
                         .resolve_rel_create_mutation(
-                            field_name, &src_label, &rel_name, info, input, executor,
+                            field_name, src_label, rel_name, info, input, executor,
                         )
                         .await
                 }
@@ -619,7 +624,7 @@ where
                     })?;
                     resolver
                         .resolve_rel_delete_mutation(
-                            field_name, &src_label, &rel_name, info, input, executor,
+                            field_name, src_label, rel_name, info, input, executor,
                         )
                         .await
                 }
@@ -632,7 +637,7 @@ where
                     })?;
                     resolver
                         .resolve_rel_update_mutation(
-                            field_name, &src_label, &rel_name, info, input, executor,
+                            field_name, src_label, rel_name, info, input, executor,
                         )
                         .await
                 }
@@ -641,8 +646,14 @@ where
                         .resolve_scalar_field(info, field_name, &self.fields, executor)
                         .await
                 }
-                PropertyKind::ScalarComp => Err((Error::TypeNotExpected { details: Some("PropertyKind::ScalarComp not expected".to_string()) }).into()),
-                PropertyKind::Union => Err((Error::TypeNotExpected { details: Some("PropertyKind::Union not expected".to_string()) }).into()),
+                PropertyKind::ScalarComp => Err((Error::TypeNotExpected {
+                    details: Some("PropertyKind::ScalarComp not expected".to_string()),
+                })
+                .into()),
+                PropertyKind::Union => Err((Error::TypeNotExpected {
+                    details: Some("PropertyKind::Union not expected".to_string()),
+                })
+                .into()),
                 PropertyKind::VersionQuery => resolver.resolve_static_version_query(executor).await,
             };
 
@@ -771,7 +782,7 @@ where
     RequestCtx: RequestContext,
 {
     fn name(info: &Self::TypeInfo) -> Option<&str> {
-        Some(&info.name())
+        Some(info.name())
     }
 
     fn meta<'r>(info: &Self::TypeInfo, registry: &mut Registry<'r>) -> MetaType<'r>
@@ -780,7 +791,7 @@ where
     {
         trace!("Rel::meta called for {}", info.name());
 
-        let nt = info.type_def_by_name(&info.name()).unwrap_or_else(|e| {
+        let nt = info.type_def_by_name(info.name()).unwrap_or_else(|e| {
             error!("Rel::meta panicking on type: {}", info.name().to_string());
             panic!("{}", e)
         });
@@ -828,12 +839,12 @@ where
     type TypeInfo = Info;
 
     fn type_name<'i>(&self, info: &'i Self::TypeInfo) -> Option<&'i str> {
-        Some(&info.name())
+        Some(info.name())
     }
 
     fn concrete_type_name(&self, _context: &Self::Context, info: &Self::TypeInfo) -> String {
         let tn = info
-            .type_def_by_name(&info.name())
+            .type_def_by_name(info.name())
             .unwrap_or_else(|e| {
                 error!("Rel::concrete_type_name panicking on type: {}", info.name());
                 panic!("{}", e)
@@ -894,7 +905,10 @@ where
                             .resolve_rel_props(info, field_name, p, executor)
                             .await
                     }
-                    None => Err(Error::TypeNotExpected { details: Some("Object is missing props".to_string()) }.into()),
+                    None => Err(Error::TypeNotExpected {
+                        details: Some("Object is missing props".to_string()),
+                    }
+                    .into()),
                 },
                 (PropertyKind::Object, &"src") => match &self.src_ref {
                     NodeRef::Identifier { id, label: _ } => {
@@ -926,16 +940,19 @@ where
                 (PropertyKind::Union, _) => match &self.dst_ref {
                     NodeRef::Identifier { id, label } => {
                         resolver
-                            .resolve_union_field(info, label, field_name, &id, executor)
+                            .resolve_union_field(info, label, field_name, id, executor)
                             .await
                     }
                     NodeRef::Node(n) => {
                         resolver
-                            .resolve_union_field_node(info, field_name, &n, executor)
+                            .resolve_union_field_node(info, field_name, n, executor)
                             .await
                     }
                 },
-                (_, _) => Err((Error::TypeNotExpected { details: Some("Unexpected PropertyKind".to_string()) }).into()),
+                (_, _) => Err((Error::TypeNotExpected {
+                    details: Some("Unexpected PropertyKind".to_string()),
+                })
+                .into()),
             }
         })
     }

--- a/src/engine/objects/resolvers/mod.rs
+++ b/src/engine/objects/resolvers/mod.rs
@@ -36,7 +36,11 @@ impl<'r> Resolver<'r> {
         Resolver { partition_key_opt }
     }
 
-    #[tracing::instrument(level="info", name = "execute_endpoint", skip(self, info, parent, args, executor))]
+    #[tracing::instrument(
+        level = "info",
+        name = "execute_endpoint",
+        skip(self, info, parent, args, executor)
+    )]
     pub(super) async fn resolve_custom_endpoint<RequestCtx: RequestContext>(
         &mut self,
         info: &Info,
@@ -93,7 +97,7 @@ impl<'r> Resolver<'r> {
             args,
             parent,
             self.partition_key_opt,
-            &executor,
+            executor,
         ))
         .await
     }
@@ -130,7 +134,11 @@ impl<'r> Resolver<'r> {
         .await
     }
 
-    #[tracing::instrument(level="info", name = "create_node", skip(self, info, input, executor))]
+    #[tracing::instrument(
+        level = "info",
+        name = "create_node",
+        skip(self, info, input, executor)
+    )]
     pub(super) async fn resolve_node_create_mutation<RequestCtx: RequestContext>(
         &mut self,
         field_name: &str,
@@ -187,7 +195,11 @@ impl<'r> Resolver<'r> {
     }
 
     #[allow(unused_variables)]
-    #[tracing::instrument(level="info", name = "delete_node", skip(self, info, input, executor))]
+    #[tracing::instrument(
+        level = "info",
+        name = "delete_node",
+        skip(self, info, input, executor)
+    )]
     pub(super) async fn resolve_node_delete_mutation<RequestCtx>(
         &mut self,
         field_name: &str,
@@ -242,7 +254,11 @@ impl<'r> Resolver<'r> {
         executor.resolve_with_ctx(&(), &results?)
     }
 
-    #[tracing::instrument(level="info", name = "read_node", skip(self, info, input_opt, executor))]
+    #[tracing::instrument(
+        level = "info",
+        name = "read_node",
+        skip(self, info, input_opt, executor)
+    )]
     pub(super) async fn resolve_node_read_query<RequestCtx: RequestContext>(
         &mut self,
         field_name: &str,
@@ -265,7 +281,7 @@ impl<'r> Resolver<'r> {
         } else {
             info.type_def_by_name("Query")?
                 .property(p.type_name())?
-                .input_type_definition(&info)?
+                .input_type_definition(info)?
         };
         let node_var = NodeQueryVar::new(
             Some(p.type_name().to_string()),
@@ -377,7 +393,11 @@ impl<'r> Resolver<'r> {
         }
     }
 
-    #[tracing::instrument(level="info", name = "update_node", skip(self, info, input, executor))]
+    #[tracing::instrument(
+        level = "info",
+        name = "update_node",
+        skip(self, info, input, executor)
+    )]
     pub(super) async fn resolve_node_update_mutation<RequestCtx: RequestContext>(
         &mut self,
         field_name: &str,
@@ -432,7 +452,7 @@ impl<'r> Resolver<'r> {
             .await
     }
 
-    #[tracing::instrument(level="info", name = "create_rel", skip(self, info, input, executor))]
+    #[tracing::instrument(level = "info", name = "create_rel", skip(self, info, input, executor))]
     pub(super) async fn resolve_rel_create_mutation<RequestCtx: RequestContext>(
         &mut self,
         field_name: &str,
@@ -492,7 +512,7 @@ impl<'r> Resolver<'r> {
             .await
     }
 
-    #[tracing::instrument(level="info", name = "delete_rel", skip(self, info, input, executor))]
+    #[tracing::instrument(level = "info", name = "delete_rel", skip(self, info, input, executor))]
     pub(super) async fn resolve_rel_delete_mutation<RequestCtx: RequestContext>(
         &mut self,
         field_name: &str,
@@ -570,7 +590,11 @@ impl<'r> Resolver<'r> {
             .await
     }
 
-    #[tracing::instrument(level="info", name = "read_rel", skip(self, info, input_opt, executor))]
+    #[tracing::instrument(
+        level = "info",
+        name = "read_rel",
+        skip(self, info, input_opt, executor)
+    )]
     pub(super) async fn resolve_rel_read_query<RequestCtx: RequestContext>(
         &mut self,
         field_name: &str,
@@ -592,7 +616,7 @@ impl<'r> Resolver<'r> {
         let td = info.type_def()?;
         let p = td.property(field_name)?;
         let itd = p.input_type_definition(info)?;
-        let rtd = info.type_def_by_name(&p.type_name())?;
+        let rtd = info.type_def_by_name(p.type_name())?;
         let src_prop = rtd.property("src")?;
 
         let dst_suffix = sg.suffix();
@@ -717,7 +741,7 @@ impl<'r> Resolver<'r> {
         }
     }
 
-    #[tracing::instrument(level="info", name = "update_rel", skip(self, info, input, executor))]
+    #[tracing::instrument(level = "info", name = "update_rel", skip(self, info, input, executor))]
     pub(super) async fn resolve_rel_update_mutation<RequestCtx: RequestContext>(
         &mut self,
         field_name: &str,
@@ -739,7 +763,7 @@ impl<'r> Resolver<'r> {
         let td = info.type_def()?;
         let p = td.property(field_name)?;
         let itd = p.input_type_definition(info)?;
-        let rtd = info.type_def_by_name(&p.type_name())?;
+        let rtd = info.type_def_by_name(p.type_name())?;
         let props_prop = rtd.property("props");
         let rel_var = RelQueryVar::new(
             rel_name.to_string(),
@@ -835,10 +859,18 @@ impl<'r> Resolver<'r> {
                         }
                     }
                     Some(Value::Array(_)) | Some(Value::Map(_)) | None => {
-                        Err((Error::TypeNotExpected { details: Some("Expected Array of scalar, found Array of Array/Map".to_string()) }).into())
+                        Err((Error::TypeNotExpected {
+                            details: Some(
+                                "Expected Array of scalar, found Array of Array/Map".to_string(),
+                            ),
+                        })
+                        .into())
                     }
                 },
-                Value::Map(_) => Err((Error::TypeNotExpected { details: Some("Expected scalar, found Map".to_string()) }).into()),
+                Value::Map(_) => Err((Error::TypeNotExpected {
+                    details: Some("Expected scalar, found Map".to_string()),
+                })
+                .into()),
             },
         )
     }

--- a/src/engine/objects/resolvers/visitors.rs
+++ b/src/engine/objects/resolvers/visitors.rs
@@ -59,7 +59,7 @@ pub(crate) fn visit_node_create_mutation_input<'a, RequestCtx: RequestContext>(
                 match p.kind() {
                     PropertyKind::Scalar | PropertyKind::DynamicScalar => {
                         p.validator().map_or(Ok(()), |v_name| {
-                            validate_input(context.validators(), &v_name, &input)
+                            validate_input(context.validators(), v_name, &input)
                         })
                     }
                     _ => Ok(()), // No validation action to take
@@ -79,7 +79,9 @@ pub(crate) fn visit_node_create_mutation_input<'a, RequestCtx: RequestContext>(
                             inputs.insert(k, v);
                         }
                         _ => {
-                            return Err(Error::TypeNotExpected { details: Some("Expected Scalar or Input".to_string()) })
+                            return Err(Error::TypeNotExpected {
+                                details: Some("Expected Scalar or Input".to_string()),
+                            })
                         }
                     }
                     Ok((props, inputs))
@@ -171,7 +173,13 @@ pub(crate) fn visit_node_create_mutation_input<'a, RequestCtx: RequestContext>(
                                 .await?;
                             }
                         }
-                        _ => return Err(Error::TypeNotExpected { details: Some("Expected Scalar, DynamicScalar, or Input".to_string()) }),
+                        _ => {
+                            return Err(Error::TypeNotExpected {
+                                details: Some(
+                                    "Expected Scalar, DynamicScalar, or Input".to_string(),
+                                ),
+                            })
+                        }
                     }
                 }
             }
@@ -180,7 +188,11 @@ pub(crate) fn visit_node_create_mutation_input<'a, RequestCtx: RequestContext>(
 
             Ok(node)
         } else {
-            Err(Error::TypeNotExpected { details: Some("Expected visit_node_create_mutation_input input to be Map".to_string()) })
+            Err(Error::TypeNotExpected {
+                details: Some(
+                    "Expected visit_node_create_mutation_input input to be Map".to_string(),
+                ),
+            })
         }
     })
 }
@@ -239,7 +251,7 @@ pub(crate) async fn visit_node_delete_input<RequestCtx: RequestContext>(
 
         visit_node_delete_mutation_input::<RequestCtx>(
             fragment,
-            &node_var,
+            node_var,
             m.remove("DELETE"),
             &Info::new(
                 itd.property("DELETE")?.type_name().to_owned(),
@@ -252,7 +264,9 @@ pub(crate) async fn visit_node_delete_input<RequestCtx: RequestContext>(
         )
         .await
     } else {
-        Err(Error::TypeNotExpected { details: Some("Expected visit_node_delete_input input to be Map".to_string()) })
+        Err(Error::TypeNotExpected {
+            details: Some("Expected visit_node_delete_input input to be Map".to_string()),
+        })
     }
 }
 
@@ -497,9 +511,9 @@ pub(crate) fn visit_node_query_input<'a, RequestCtx: RequestContext>(
                 }
             }
 
-            transaction.node_read_fragment(rqfs, &node_var, props, sg)
+            transaction.node_read_fragment(rqfs, node_var, props, sg)
         } else {
-            transaction.node_read_fragment(Vec::new(), &node_var, HashMap::new(), sg)
+            transaction.node_read_fragment(Vec::new(), node_var, HashMap::new(), sg)
         }
     })
 }
@@ -607,7 +621,7 @@ fn visit_node_update_mutation_input<'a, RequestCtx: RequestContext>(
                 match p.kind() {
                     PropertyKind::Scalar | PropertyKind::DynamicScalar => {
                         p.validator().map_or(Ok(()), |v_name| {
-                            validate_input(context.validators(), &v_name, &input)
+                            validate_input(context.validators(), v_name, &input)
                         })
                     }
                     _ => Ok(()), // No validation action to take
@@ -996,7 +1010,9 @@ async fn visit_rel_create_mutation_input<RequestCtx: RequestContext>(
         }
         Ok(rels)
     } else {
-        Err(Error::TypeNotExpected { details: Some("visit_rel_create_mutation_input input is not Map".to_string()) })
+        Err(Error::TypeNotExpected {
+            details: Some("visit_rel_create_mutation_input input is not Map".to_string()),
+        })
     }
 }
 
@@ -1537,7 +1553,7 @@ pub(super) async fn visit_rel_update_input<RequestCtx: RequestContext>(
 
         let fragment = visit_rel_query_input::<RequestCtx>(
             src_fragment_opt,
-            &rel_var,
+            rel_var,
             m.remove("MATCH"), // uses remove to take ownership
             &Info::new(
                 itd.property("MATCH")?.type_name().to_owned(),
@@ -1555,7 +1571,7 @@ pub(super) async fn visit_rel_update_input<RequestCtx: RequestContext>(
             // remove used to take ownership
             visit_rel_update_mutation_input::<RequestCtx>(
                 fragment,
-                &rel_var,
+                rel_var,
                 props_type_name,
                 update,
                 &Info::new(

--- a/src/engine/resolvers.rs
+++ b/src/engine/resolvers.rs
@@ -4,11 +4,11 @@
 use crate::engine::context::GraphQLContext;
 use crate::engine::context::RequestContext;
 use crate::engine::database::{
-    DatabaseEndpoint, DatabasePool, NodeQueryVar, SuffixGenerator, Transaction, RelQueryVar
+    DatabaseEndpoint, DatabasePool, NodeQueryVar, RelQueryVar, SuffixGenerator, Transaction,
 };
 use crate::engine::objects::resolvers::visitors::{
     visit_node_create_mutation_input, visit_node_query_input, visit_node_update_input,
-    visit_rel_query_input
+    visit_rel_query_input,
 };
 use crate::engine::objects::{Node, NodeRef, Rel};
 use crate::engine::schema::Info;
@@ -254,7 +254,6 @@ where
         results
     }
 
-
     /// Provides an abstracted database rel read operation using warpgrapher inputs. This is the
     /// recommended way to read relationships in a database-agnostic way that ensures the event handlers
     /// are portable across different databases.
@@ -331,17 +330,11 @@ where
         .await?;
 
         let results = transaction
-            .read_rels(
-                query_fragment,
-                &rel_var,
-                None,
-                partition_key_opt,
-            )
+            .read_rels(query_fragment, &rel_var, None, partition_key_opt)
             .await?;
 
         Ok(results)
     }
-
 
     /// Provides an abstracted database node create operation using warpgrapher inputs. This is the
     /// recommended way to read data in a database-agnostic way that ensures the event handlers
@@ -613,7 +606,9 @@ where
                 },
             ))
         } else {
-            Err(Error::TypeNotExpected { details: Some("parent_node is not of type Object::Node".to_string()) })
+            Err(Error::TypeNotExpected {
+                details: Some("parent_node is not of type Object::Node".to_string()),
+            })
         }
     }
 
@@ -670,7 +665,9 @@ where
                 NodeRef::Node(dst),
             ))
         } else {
-            Err(Error::TypeNotExpected { details: Some("parent_node is not of type Object::Node".to_string()) })
+            Err(Error::TypeNotExpected {
+                details: Some("parent_node is not of type Object::Node".to_string()),
+            })
         }
     }
 
@@ -752,7 +749,9 @@ where
         if let Object::Node(n) = self.parent {
             Ok(n)
         } else {
-            Err(Error::TypeNotExpected { details: Some("parent_node is not of type Object::Node".to_string()) })
+            Err(Error::TypeNotExpected {
+                details: Some("parent_node is not of type Object::Node".to_string()),
+            })
         }
     }
 
@@ -856,7 +855,6 @@ where
             )
             .await
     }
-    
 
     /// Returns a GraphQL Object representing a list of graph node defined by a type and a map of props.
     ///
@@ -884,7 +882,10 @@ where
     pub async fn resolve_node_list(&self, node_list: Vec<Node<RequestCtx>>) -> ExecutionResult {
         self.executor
             .resolve_async(
-                &Info::new(node_list.first().unwrap().typename().to_string(), self.info.type_defs()),
+                &Info::new(
+                    node_list.first().unwrap().typename().to_string(),
+                    self.info.type_defs(),
+                ),
                 &node_list,
             )
             .await

--- a/src/engine/schema.rs
+++ b/src/engine/schema.rs
@@ -277,40 +277,37 @@ fn generate_create_props(props: &[crate::engine::config::Property]) -> HashMap<S
     );
 
     // insert properties into hashmap
-    props
-        .iter()
-        .filter(|p| p.uses_filter().create())
-        .for_each(|p| {
-            match &p.resolver() {
-                None => {
-                    hm.insert(
+    props.iter().filter(|p| p.uses().create()).for_each(|p| {
+        match &p.resolver() {
+            None => {
+                hm.insert(
+                    p.name().to_string(),
+                    Property::new(
                         p.name().to_string(),
-                        Property::new(
-                            p.name().to_string(),
-                            PropertyKind::Scalar,
-                            p.type_name().to_string(),
-                        )
-                        .with_required(p.required())
-                        .with_list(p.list())
-                        .with_validator(p.validator().cloned()),
-                    );
-                }
-                Some(r) => {
-                    hm.insert(
+                        PropertyKind::Scalar,
+                        p.type_name().to_string(),
+                    )
+                    .with_required(p.required())
+                    .with_list(p.list())
+                    .with_validator(p.validator().cloned()),
+                );
+            }
+            Some(r) => {
+                hm.insert(
+                    p.name().to_string(),
+                    Property::new(
                         p.name().to_string(),
-                        Property::new(
-                            p.name().to_string(),
-                            PropertyKind::DynamicScalar,
-                            p.type_name().to_string(),
-                        )
-                        .with_required(p.required())
-                        .with_list(p.list())
-                        .with_resolver(r)
-                        .with_validator(p.validator().cloned()),
-                    );
-                }
-            };
-        });
+                        PropertyKind::DynamicScalar,
+                        p.type_name().to_string(),
+                    )
+                    .with_required(p.required())
+                    .with_list(p.list())
+                    .with_resolver(r)
+                    .with_validator(p.validator().cloned()),
+                );
+            }
+        };
+    });
 
     hm
 }
@@ -321,40 +318,37 @@ fn generate_update_props(props: &[crate::engine::config::Property]) -> HashMap<S
     let mut hm = HashMap::new();
 
     // insert properties into hashmap
-    props
-        .iter()
-        .filter(|p| p.uses_filter().update())
-        .for_each(|p| {
-            match &p.resolver() {
-                None => {
-                    hm.insert(
+    props.iter().filter(|p| p.uses().update()).for_each(|p| {
+        match &p.resolver() {
+            None => {
+                hm.insert(
+                    p.name().to_string(),
+                    Property::new(
                         p.name().to_string(),
-                        Property::new(
-                            p.name().to_string(),
-                            PropertyKind::Scalar,
-                            p.type_name().to_string(),
-                        )
-                        .with_required(false)
-                        .with_list(p.list())
-                        .with_validator(p.validator().cloned()),
-                    );
-                }
-                Some(r) => {
-                    hm.insert(
+                        PropertyKind::Scalar,
+                        p.type_name().to_string(),
+                    )
+                    .with_required(false)
+                    .with_list(p.list())
+                    .with_validator(p.validator().cloned()),
+                );
+            }
+            Some(r) => {
+                hm.insert(
+                    p.name().to_string(),
+                    Property::new(
                         p.name().to_string(),
-                        Property::new(
-                            p.name().to_string(),
-                            PropertyKind::DynamicScalar,
-                            p.type_name().to_string(),
-                        )
-                        .with_required(false)
-                        .with_list(p.list())
-                        .with_resolver(r)
-                        .with_validator(p.validator().cloned()),
-                    );
-                }
-            };
-        });
+                        PropertyKind::DynamicScalar,
+                        p.type_name().to_string(),
+                    )
+                    .with_required(false)
+                    .with_list(p.list())
+                    .with_resolver(r)
+                    .with_validator(p.validator().cloned()),
+                );
+            }
+        };
+    });
 
     hm
 }
@@ -377,40 +371,37 @@ fn generate_output_props(
     }
 
     // insert properties into hashmap
-    props
-        .iter()
-        .filter(|p| p.uses_filter().output())
-        .for_each(|p| {
-            match &p.resolver() {
-                None => {
-                    hm.insert(
+    props.iter().filter(|p| p.uses().output()).for_each(|p| {
+        match &p.resolver() {
+            None => {
+                hm.insert(
+                    p.name().to_string(),
+                    Property::new(
                         p.name().to_string(),
-                        Property::new(
-                            p.name().to_string(),
-                            PropertyKind::Scalar,
-                            p.type_name().to_string(),
-                        )
-                        .with_required(p.required())
-                        .with_list(p.list())
-                        .with_validator(p.validator().cloned()),
-                    );
-                }
-                Some(r) => {
-                    hm.insert(
+                        PropertyKind::Scalar,
+                        p.type_name().to_string(),
+                    )
+                    .with_required(p.required())
+                    .with_list(p.list())
+                    .with_validator(p.validator().cloned()),
+                );
+            }
+            Some(r) => {
+                hm.insert(
+                    p.name().to_string(),
+                    Property::new(
                         p.name().to_string(),
-                        Property::new(
-                            p.name().to_string(),
-                            PropertyKind::DynamicScalar,
-                            p.type_name().to_string(),
-                        )
-                        .with_required(p.required())
-                        .with_list(p.list())
-                        .with_resolver(r)
-                        .with_validator(p.validator().cloned()),
-                    );
-                }
-            };
-        });
+                        PropertyKind::DynamicScalar,
+                        p.type_name().to_string(),
+                    )
+                    .with_required(p.required())
+                    .with_list(p.list())
+                    .with_resolver(r)
+                    .with_validator(p.validator().cloned()),
+                );
+            }
+        };
+    });
 
     hm
 }
@@ -433,7 +424,7 @@ fn generate_query_props(
             ),
         );
     }
-    for p in props.iter().filter(|p| p.uses_filter().query()) {
+    for p in props.iter().filter(|p| p.uses().query()) {
         query_props.insert(
             p.name().to_string(),
             Property::new(

--- a/src/engine/schema.rs
+++ b/src/engine/schema.rs
@@ -266,55 +266,151 @@ impl Argument {
 }
 
 /// Takes a vector of WG Properties and returns a map of Property structs that
-/// represent the property fields in a graphql schema component
-fn generate_props(
+/// represent the property fields in a graphql schema component for an object to be created
+fn generate_create_props(props: &[crate::engine::config::Property]) -> HashMap<String, Property> {
+    let mut hm = HashMap::new();
+
+    hm.insert(
+        "id".to_string(),
+        Property::new("id".to_string(), PropertyKind::Scalar, "ID".to_string())
+            .with_required(false),
+    );
+
+    // insert properties into hashmap
+    props
+        .iter()
+        .filter(|p| p.uses_filter().create())
+        .for_each(|p| {
+            match &p.resolver() {
+                None => {
+                    hm.insert(
+                        p.name().to_string(),
+                        Property::new(
+                            p.name().to_string(),
+                            PropertyKind::Scalar,
+                            p.type_name().to_string(),
+                        )
+                        .with_required(p.required())
+                        .with_list(p.list())
+                        .with_validator(p.validator().cloned()),
+                    );
+                }
+                Some(r) => {
+                    hm.insert(
+                        p.name().to_string(),
+                        Property::new(
+                            p.name().to_string(),
+                            PropertyKind::DynamicScalar,
+                            p.type_name().to_string(),
+                        )
+                        .with_required(p.required())
+                        .with_list(p.list())
+                        .with_resolver(r)
+                        .with_validator(p.validator().cloned()),
+                    );
+                }
+            };
+        });
+
+    hm
+}
+
+/// Takes a vector of WG Properties and returns a map of Property structs that
+/// represent the property fields in a graphql schema component for an object to be updated
+fn generate_update_props(props: &[crate::engine::config::Property]) -> HashMap<String, Property> {
+    let mut hm = HashMap::new();
+
+    // insert properties into hashmap
+    props
+        .iter()
+        .filter(|p| p.uses_filter().update())
+        .for_each(|p| {
+            match &p.resolver() {
+                None => {
+                    hm.insert(
+                        p.name().to_string(),
+                        Property::new(
+                            p.name().to_string(),
+                            PropertyKind::Scalar,
+                            p.type_name().to_string(),
+                        )
+                        .with_required(false)
+                        .with_list(p.list())
+                        .with_validator(p.validator().cloned()),
+                    );
+                }
+                Some(r) => {
+                    hm.insert(
+                        p.name().to_string(),
+                        Property::new(
+                            p.name().to_string(),
+                            PropertyKind::DynamicScalar,
+                            p.type_name().to_string(),
+                        )
+                        .with_required(false)
+                        .with_list(p.list())
+                        .with_resolver(r)
+                        .with_validator(p.validator().cloned()),
+                    );
+                }
+            };
+        });
+
+    hm
+}
+
+/// Takes a vector of WG Properties and returns a map of Property structs that
+/// represent the property fields in a graphql schema component for an object to be returned by the
+/// API
+fn generate_output_props(
     props: &[crate::engine::config::Property],
     id: bool,
-    object: bool,
 ) -> HashMap<String, Property> {
     let mut hm = HashMap::new();
 
-    // if the ID field was specified, add it
     if id {
         hm.insert(
             "id".to_string(),
             Property::new("id".to_string(), PropertyKind::Scalar, "ID".to_string())
-                .with_required(object),
+                .with_required(true),
         );
     }
 
     // insert properties into hashmap
-    props.iter().filter(|p| !p.hidden()).for_each(|p| {
-        match &p.resolver() {
-            None => {
-                hm.insert(
-                    p.name().to_string(),
-                    Property::new(
+    props
+        .iter()
+        .filter(|p| p.uses_filter().output())
+        .for_each(|p| {
+            match &p.resolver() {
+                None => {
+                    hm.insert(
                         p.name().to_string(),
-                        PropertyKind::Scalar,
-                        p.type_name().to_string(),
-                    )
-                    .with_required(p.required() && object)
-                    .with_list(p.list())
-                    .with_validator(p.validator().cloned()),
-                );
-            }
-            Some(r) => {
-                hm.insert(
-                    p.name().to_string(),
-                    Property::new(
+                        Property::new(
+                            p.name().to_string(),
+                            PropertyKind::Scalar,
+                            p.type_name().to_string(),
+                        )
+                        .with_required(p.required())
+                        .with_list(p.list())
+                        .with_validator(p.validator().cloned()),
+                    );
+                }
+                Some(r) => {
+                    hm.insert(
                         p.name().to_string(),
-                        PropertyKind::DynamicScalar,
-                        p.type_name().to_string(),
-                    )
-                    .with_required(p.required() && object)
-                    .with_list(p.list())
-                    .with_resolver(r)
-                    .with_validator(p.validator().cloned()),
-                );
-            }
-        };
-    });
+                        Property::new(
+                            p.name().to_string(),
+                            PropertyKind::DynamicScalar,
+                            p.type_name().to_string(),
+                        )
+                        .with_required(p.required())
+                        .with_list(p.list())
+                        .with_resolver(r)
+                        .with_validator(p.validator().cloned()),
+                    );
+                }
+            };
+        });
 
     hm
 }
@@ -337,7 +433,7 @@ fn generate_query_props(
             ),
         );
     }
-    for p in props.iter().filter(|p| !p.hidden()) {
+    for p in props.iter().filter(|p| p.uses_filter().query()) {
         query_props.insert(
             p.name().to_string(),
             Property::new(
@@ -396,7 +492,7 @@ fn fmt_node_object_name(t: &Type) -> String {
 ///     owner: ProjectOwnerRel
 /// }
 fn generate_node_object(t: &Type) -> NodeType {
-    let mut props = generate_props(&t.props_as_slice(), true, true);
+    let mut props = generate_output_props(t.props_as_slice(), true);
 
     t.rels().for_each(|r| {
         let mut arguments = HashMap::new();
@@ -419,7 +515,7 @@ fn generate_node_object(t: &Type) -> NodeType {
                     rel_name: r.name().to_string(),
                 },
             },
-            fmt_rel_object_name(t, &r),
+            fmt_rel_object_name(t, r),
         )
         .with_list(r.list())
         .with_arguments(arguments);
@@ -462,7 +558,7 @@ fn generate_node_query_input(t: &Type) -> Result<NodeType, Error> {
             Property::new(
                 r.name().to_string(),
                 PropertyKind::Input,
-                fmt_rel_query_input_name(t, &r),
+                fmt_rel_query_input_name(t, r),
             ), //.with_list(r.list()),
         );
     });
@@ -492,7 +588,7 @@ fn fmt_node_create_mutation_input_name(t: &Type) -> String {
 ///     owner: ProjectOwnerMutationInput
 /// }
 fn generate_node_create_mutation_input(t: &Type) -> NodeType {
-    let mut props = generate_props(t.props_as_slice(), true, false);
+    let mut props = generate_create_props(t.props_as_slice());
 
     t.rels().for_each(|r| {
         props.insert(
@@ -500,7 +596,7 @@ fn generate_node_create_mutation_input(t: &Type) -> NodeType {
             Property::new(
                 r.name().to_string(),
                 PropertyKind::Input,
-                fmt_rel_create_mutation_input_name(t, &r),
+                fmt_rel_create_mutation_input_name(t, r),
             )
             .with_list(r.list()),
         );
@@ -533,7 +629,7 @@ fn fmt_node_update_mutation_input_name(t: &Type) -> String {
 ///     issues: ProjectIssuesChangeInput
 /// }
 fn generate_node_update_mutation_input(t: &Type) -> NodeType {
-    let mut props = generate_props(t.props_as_slice(), false, false);
+    let mut props = generate_update_props(t.props_as_slice());
 
     t.rels().for_each(|r| {
         props.insert(
@@ -541,7 +637,7 @@ fn generate_node_update_mutation_input(t: &Type) -> NodeType {
             Property::new(
                 r.name().to_string(),
                 PropertyKind::Input,
-                fmt_rel_change_input_name(t, &r),
+                fmt_rel_change_input_name(t, r),
             )
             .with_list(r.list()),
         );
@@ -696,7 +792,7 @@ fn generate_node_delete_mutation_input(t: &Type) -> NodeType {
             Property::new(
                 r.name().to_string(),
                 PropertyKind::Input,
-                fmt_rel_delete_input_name(t, &r),
+                fmt_rel_delete_input_name(t, r),
             )
             .with_list(r.list()),
         );
@@ -962,7 +1058,7 @@ fn generate_rel_props_object(t: &Type, r: &Relationship) -> NodeType {
     NodeType::new(
         fmt_rel_props_object_name(t, r),
         TypeKind::Object,
-        generate_props(r.props_as_slice(), false, true),
+        generate_output_props(r.props_as_slice(), false),
     )
 }
 
@@ -1325,7 +1421,7 @@ fn generate_rel_props_input(t: &Type, r: &Relationship) -> NodeType {
     NodeType::new(
         fmt_rel_props_input_name(t, r),
         TypeKind::Input,
-        generate_props(r.props_as_slice(), false, false),
+        generate_update_props(r.props_as_slice()),
     )
 }
 
@@ -1502,7 +1598,7 @@ fn generate_rel_create_input(t: &Type, r: &Relationship) -> NodeType {
         Property::new(
             "CREATE".to_string(),
             PropertyKind::Input,
-            fmt_rel_create_mutation_input_name(t, &r),
+            fmt_rel_create_mutation_input_name(t, r),
         )
         .with_list(r.list()),
     );
@@ -1546,7 +1642,7 @@ fn generate_rel_update_input(t: &Type, r: &Relationship) -> NodeType {
         Property::new(
             "SET".to_string(),
             PropertyKind::Input,
-            fmt_rel_update_mutation_input_name(t, &r),
+            fmt_rel_update_mutation_input_name(t, r),
         )
         .with_required(true),
     );
@@ -1936,14 +2032,14 @@ fn generate_custom_endpoint(e: &Endpoint) -> Property {
 }
 
 fn generate_custom_endpoint_input(t: &Type) -> NodeType {
-    let mut props = generate_props(t.props_as_slice(), false, false);
+    let mut props = generate_update_props(t.props_as_slice());
     t.rels().for_each(|r| {
         props.insert(
             r.name().to_string(),
             Property::new(
                 r.name().to_string(),
                 PropertyKind::Input,
-                fmt_rel_query_input_name(t, &r),
+                fmt_rel_query_input_name(t, r),
             )
             .with_list(r.list()),
         );
@@ -2281,14 +2377,14 @@ pub(crate) fn generate_schema(c: &Configuration) -> Result<HashMap<String, NodeT
         // add custom input type if provided
         if let Some(input) = e.input() {
             if let TypeDef::Custom(t) = input.type_def() {
-                let input = generate_custom_endpoint_input(&t);
+                let input = generate_custom_endpoint_input(t);
                 nthm.insert(t.name().to_string(), input);
             }
         }
 
         // add custom output type if provided
         if let TypeDef::Custom(t) = &e.output().type_def() {
-            let node_type = generate_node_object(&t);
+            let node_type = generate_node_object(t);
             nthm.insert(node_type.type_name.to_string(), node_type);
         }
     });
@@ -2720,7 +2816,7 @@ mod tests {
         assert!(project_name.name == "name");
         assert!(project_name.kind == PropertyKind::Scalar);
         assert!(project_name.type_name == "String");
-        assert!(!project_name.required);
+        assert!(project_name.required);
         assert!(!project_name.list);
         assert!(project_name.arguments.is_empty());
         let project_tags = project_mutation_input.props.get("tags").unwrap();
@@ -2734,7 +2830,7 @@ mod tests {
         assert!(project_public.name == "public");
         assert!(project_public.kind == PropertyKind::Scalar);
         assert!(project_public.type_name == "Boolean");
-        assert!(!project_public.required);
+        assert!(project_public.required);
         assert!(!project_public.list);
         assert!(project_public.arguments.is_empty());
         let project_owner = project_mutation_input.props.get("owner").unwrap();
@@ -3122,7 +3218,7 @@ mod tests {
     fn test_fmt_rel_object_name() {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
-        assert!(fmt_rel_object_name(&project_type, &project_owner_rel) == "ProjectOwnerRel");
+        assert!(fmt_rel_object_name(&project_type, project_owner_rel) == "ProjectOwnerRel");
     }
 
     /// Passes if the right schema elements are generated
@@ -3139,7 +3235,7 @@ mod tests {
         */
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
-        let project_owner_object = generate_rel_object(&project_type, &project_owner_rel);
+        let project_owner_object = generate_rel_object(&project_type, project_owner_rel);
         let project_owner_id = project_owner_object.props.get("id").unwrap();
         assert!(project_owner_id.name == "id");
         assert!(project_owner_id.kind == PropertyKind::Scalar);
@@ -3178,7 +3274,7 @@ mod tests {
         */
         let project_type = mock_project_type();
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
-        let project_board_object = generate_rel_object(&project_type, &project_board_rel);
+        let project_board_object = generate_rel_object(&project_type, project_board_rel);
         let project_board_id = project_board_object.props.get("id").unwrap();
         assert!(project_board_id.name == "id");
         assert!(project_board_id.kind == PropertyKind::Scalar);
@@ -3209,9 +3305,7 @@ mod tests {
     fn test_fmt_rel_props_object_name() {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
-        assert!(
-            fmt_rel_props_object_name(&project_type, &project_owner_rel) == "ProjectOwnerProps"
-        );
+        assert!(fmt_rel_props_object_name(&project_type, project_owner_rel) == "ProjectOwnerProps");
     }
 
     /// Passes if the right schema elements are generated
@@ -3226,7 +3320,8 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_props_object =
-            generate_rel_props_object(&project_type, &project_owner_rel);
+            generate_rel_props_object(&project_type, project_owner_rel);
+        println!("{:#?}", project_owner_props_object.props);
         assert!(project_owner_props_object.props.len() == 1);
         let project_owner_props_name = project_owner_props_object.props.get("since").unwrap();
         assert!(project_owner_props_name.name == "since");
@@ -3243,7 +3338,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_nodes_union_name(&project_type, &project_owner_rel) == "ProjectOwnerNodesUnion"
+            fmt_rel_nodes_union_name(&project_type, project_owner_rel) == "ProjectOwnerNodesUnion"
         );
     }
 
@@ -3255,7 +3350,7 @@ mod tests {
         */
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
-        let project_owner_nodes_union = generate_rel_nodes_union(&project_type, &project_owner_rel);
+        let project_owner_nodes_union = generate_rel_nodes_union(&project_type, project_owner_rel);
         assert!(project_owner_nodes_union.type_name == "ProjectOwnerNodesUnion");
         assert!(project_owner_nodes_union.type_kind == TypeKind::Union);
         assert!(project_owner_nodes_union.props.is_empty());
@@ -3267,7 +3362,7 @@ mod tests {
         */
         let project_type = mock_project_type();
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
-        let project_board_nodes_union = generate_rel_nodes_union(&project_type, &project_board_rel);
+        let project_board_nodes_union = generate_rel_nodes_union(&project_type, project_board_rel);
         assert!(project_board_nodes_union.type_name == "ProjectBoardNodesUnion");
         assert!(project_board_nodes_union.type_kind == TypeKind::Union);
         assert!(project_board_nodes_union.props.is_empty());
@@ -3283,7 +3378,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_query_input_name(&project_type, &project_owner_rel) == "ProjectOwnerQueryInput"
+            fmt_rel_query_input_name(&project_type, project_owner_rel) == "ProjectOwnerQueryInput"
         );
     }
 
@@ -3301,7 +3396,7 @@ mod tests {
         */
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
-        let project_owner_query_input = generate_rel_query_input(&project_type, &project_owner_rel);
+        let project_owner_query_input = generate_rel_query_input(&project_type, project_owner_rel);
         // id
         let project_owner_id = project_owner_query_input.props.get("id").unwrap();
         assert!(project_owner_id.name == "id");
@@ -3343,7 +3438,7 @@ mod tests {
             }
         */
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
-        let project_board_query_input = generate_rel_query_input(&project_type, &project_board_rel);
+        let project_board_query_input = generate_rel_query_input(&project_type, project_board_rel);
         // id
         let project_board_id = project_board_query_input.props.get("id").unwrap();
         assert!(project_board_id.name == "id");
@@ -3378,7 +3473,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_create_mutation_input_name(&project_type, &project_owner_rel)
+            fmt_rel_create_mutation_input_name(&project_type, project_owner_rel)
                 == "ProjectOwnerCreateMutationInput"
         );
     }
@@ -3395,7 +3490,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_mutation_input =
-            generate_rel_create_mutation_input(&project_type, &project_owner_rel);
+            generate_rel_create_mutation_input(&project_type, project_owner_rel);
         assert!(project_owner_mutation_input.type_name == "ProjectOwnerCreateMutationInput");
         // properties
         let project_owner_props = project_owner_mutation_input.props.get("props").unwrap();
@@ -3420,7 +3515,7 @@ mod tests {
         */
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
         let project_board_mutation_input =
-            generate_rel_create_mutation_input(&project_type, &project_board_rel);
+            generate_rel_create_mutation_input(&project_type, project_board_rel);
         assert!(project_board_mutation_input.type_name == "ProjectBoardCreateMutationInput");
         // properties
         let project_board_props = project_board_mutation_input.props.get("props");
@@ -3441,7 +3536,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_issues_rel = project_type.rels().find(|&r| r.name() == "issues").unwrap();
         assert!(
-            fmt_rel_change_input_name(&project_type, &project_issues_rel)
+            fmt_rel_change_input_name(&project_type, project_issues_rel)
                 == "ProjectIssuesChangeInput"
         );
     }
@@ -3459,7 +3554,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_issues_rel = project_type.rels().find(|&r| r.name() == "issues").unwrap();
         let project_issues_change_input =
-            generate_rel_change_input(&project_type, &project_issues_rel);
+            generate_rel_change_input(&project_type, project_issues_rel);
         assert!(project_issues_change_input.type_name == "ProjectIssuesChangeInput");
         // ADD
         let project_issues_add = project_issues_change_input.props.get("ADD").unwrap();
@@ -3493,7 +3588,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_update_mutation_input_name(&project_type, &project_owner_rel)
+            fmt_rel_update_mutation_input_name(&project_type, project_owner_rel)
                 == "ProjectOwnerUpdateMutationInput"
         );
     }
@@ -3511,7 +3606,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_update_mutation_input =
-            generate_rel_update_mutation_input(&project_type, &project_owner_rel);
+            generate_rel_update_mutation_input(&project_type, project_owner_rel);
         assert!(project_owner_update_mutation_input.type_name == "ProjectOwnerUpdateMutationInput");
         // properties
         let props = project_owner_update_mutation_input
@@ -3554,7 +3649,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_src_update_mutation_input_name(&project_type, &project_owner_rel)
+            fmt_rel_src_update_mutation_input_name(&project_type, project_owner_rel)
                 == "ProjectOwnerSrcUpdateMutationInput"
         );
     }
@@ -3570,7 +3665,7 @@ mod tests {
         */
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_src_update_mutation_input =
-            generate_rel_src_update_mutation_input(&project_type, &project_owner_rel);
+            generate_rel_src_update_mutation_input(&project_type, project_owner_rel);
         assert!(
             project_owner_src_update_mutation_input.type_name
                 == "ProjectOwnerSrcUpdateMutationInput"
@@ -3592,7 +3687,7 @@ mod tests {
         */
         let project_issues_rel = project_type.rels().find(|&r| r.name() == "issues").unwrap();
         let project_issues_src_update_mutation_input =
-            generate_rel_src_update_mutation_input(&project_type, &project_issues_rel);
+            generate_rel_src_update_mutation_input(&project_type, project_issues_rel);
         assert!(
             project_issues_src_update_mutation_input.type_name
                 == "ProjectIssuesSrcUpdateMutationInput"
@@ -3620,7 +3715,7 @@ mod tests {
         */
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_dst_update_mutation_input_name(&project_type, &project_owner_rel)
+            fmt_rel_dst_update_mutation_input_name(&project_type, project_owner_rel)
                 == "ProjectOwnerDstUpdateMutationInput"
         );
     }
@@ -3636,7 +3731,7 @@ mod tests {
         */
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_dst_update_mutation_input =
-            generate_rel_dst_update_mutation_input(&project_type, &project_owner_rel);
+            generate_rel_dst_update_mutation_input(&project_type, project_owner_rel);
         assert!(
             project_owner_dst_update_mutation_input.type_name
                 == "ProjectOwnerDstUpdateMutationInput"
@@ -3659,7 +3754,7 @@ mod tests {
         */
         let project_issues_rel = project_type.rels().find(|&r| r.name() == "issues").unwrap();
         let project_issues_dst_update_mutation_input =
-            generate_rel_dst_update_mutation_input(&project_type, &project_issues_rel);
+            generate_rel_dst_update_mutation_input(&project_type, project_issues_rel);
         assert!(
             project_issues_dst_update_mutation_input.type_name
                 == "ProjectIssuesDstUpdateMutationInput"
@@ -3692,7 +3787,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_props_input_name(&project_type, &project_owner_rel) == "ProjectOwnerPropsInput"
+            fmt_rel_props_input_name(&project_type, project_owner_rel) == "ProjectOwnerPropsInput"
         );
     }
 
@@ -3701,7 +3796,7 @@ mod tests {
     fn test_generate_rel_props_input() {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
-        let project_owner_props_input = generate_rel_props_input(&project_type, &project_owner_rel);
+        let project_owner_props_input = generate_rel_props_input(&project_type, project_owner_rel);
         assert!(project_owner_props_input.type_name == "ProjectOwnerPropsInput");
         assert!(project_owner_props_input.type_kind == TypeKind::Input);
         assert!(project_owner_props_input.props.len() == 1);
@@ -3720,12 +3815,12 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_src_query_input_name(&project_type, &project_owner_rel)
+            fmt_rel_src_query_input_name(&project_type, project_owner_rel)
                 == "ProjectOwnerSrcQueryInput"
         );
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
         assert!(
-            fmt_rel_src_query_input_name(&project_type, &project_board_rel)
+            fmt_rel_src_query_input_name(&project_type, project_board_rel)
                 == "ProjectBoardSrcQueryInput"
         );
     }
@@ -3736,12 +3831,12 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_dst_query_input_name(&project_type, &project_owner_rel)
+            fmt_rel_dst_query_input_name(&project_type, project_owner_rel)
                 == "ProjectOwnerDstQueryInput"
         );
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
         assert!(
-            fmt_rel_dst_query_input_name(&project_type, &project_board_rel)
+            fmt_rel_dst_query_input_name(&project_type, project_board_rel)
                 == "ProjectBoardDstQueryInput"
         );
     }
@@ -3757,7 +3852,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_nodes_query_input_union =
-            generate_rel_dst_query_input(&project_type, &project_owner_rel);
+            generate_rel_dst_query_input(&project_type, project_owner_rel);
         assert!(project_owner_nodes_query_input_union.type_name == "ProjectOwnerDstQueryInput");
         assert!(project_owner_nodes_query_input_union.type_kind == TypeKind::Input);
         assert!(project_owner_nodes_query_input_union.props.len() == 1);
@@ -3779,7 +3874,7 @@ mod tests {
         */
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
         let project_board_nodes_query_input_union =
-            generate_rel_dst_query_input(&project_type, &project_board_rel);
+            generate_rel_dst_query_input(&project_type, project_board_rel);
         assert!(project_board_nodes_query_input_union.type_name == "ProjectBoardDstQueryInput");
         assert!(project_board_nodes_query_input_union.type_kind == TypeKind::Input);
         assert!(project_board_nodes_query_input_union.props.len() == 2);
@@ -3811,12 +3906,12 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_nodes_mutation_input_union_name(&project_type, &project_owner_rel)
+            fmt_rel_nodes_mutation_input_union_name(&project_type, project_owner_rel)
                 == "ProjectOwnerNodesMutationInputUnion"
         );
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
         assert!(
-            fmt_rel_nodes_mutation_input_union_name(&project_type, &project_board_rel)
+            fmt_rel_nodes_mutation_input_union_name(&project_type, project_board_rel)
                 == "ProjectBoardNodesMutationInputUnion"
         );
     }
@@ -3832,7 +3927,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_nodes_mutation_input_union =
-            generate_rel_nodes_mutation_input_union(&project_type, &project_owner_rel);
+            generate_rel_nodes_mutation_input_union(&project_type, project_owner_rel);
         assert!(
             project_owner_nodes_mutation_input_union.type_name
                 == "ProjectOwnerNodesMutationInputUnion"
@@ -3857,7 +3952,7 @@ mod tests {
         */
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
         let project_board_nodes_mutation_input_union =
-            generate_rel_nodes_mutation_input_union(&project_type, &project_board_rel);
+            generate_rel_nodes_mutation_input_union(&project_type, project_board_rel);
         assert!(
             project_board_nodes_mutation_input_union.type_name
                 == "ProjectBoardNodesMutationInputUnion"
@@ -3892,12 +3987,12 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_create_input_name(&project_type, &project_owner_rel)
+            fmt_rel_create_input_name(&project_type, project_owner_rel)
                 == "ProjectOwnerCreateInput"
         );
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
         assert!(
-            fmt_rel_create_input_name(&project_type, &project_board_rel)
+            fmt_rel_create_input_name(&project_type, project_board_rel)
                 == "ProjectBoardCreateInput"
         );
     }
@@ -3915,7 +4010,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_create_input =
-            generate_rel_create_input(&project_type, &project_owner_rel);
+            generate_rel_create_input(&project_type, project_owner_rel);
         assert!(project_owner_create_input.type_name == "ProjectOwnerCreateInput");
         assert!(project_owner_create_input.type_kind == TypeKind::Input);
         assert!(project_owner_create_input.props.len() == 2);
@@ -3941,7 +4036,7 @@ mod tests {
         */
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
         let project_board_create_input =
-            generate_rel_create_input(&project_type, &project_board_rel);
+            generate_rel_create_input(&project_type, project_board_rel);
         assert!(project_board_create_input.type_name == "ProjectBoardCreateInput");
         assert!(project_board_create_input.type_kind == TypeKind::Input);
         assert!(project_board_create_input.props.len() == 2);
@@ -3967,12 +4062,12 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_update_input_name(&project_type, &project_owner_rel)
+            fmt_rel_update_input_name(&project_type, project_owner_rel)
                 == "ProjectOwnerUpdateInput"
         );
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
         assert!(
-            fmt_rel_update_input_name(&project_type, &project_board_rel)
+            fmt_rel_update_input_name(&project_type, project_board_rel)
                 == "ProjectBoardUpdateInput"
         );
     }
@@ -3990,7 +4085,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_update_input =
-            generate_rel_update_input(&project_type, &project_owner_rel);
+            generate_rel_update_input(&project_type, project_owner_rel);
         assert!(project_owner_update_input.type_name == "ProjectOwnerUpdateInput");
         assert!(project_owner_update_input.type_kind == TypeKind::Input);
         assert!(project_owner_update_input.props.len() == 2);
@@ -4016,7 +4111,7 @@ mod tests {
         */
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
         let project_board_update_input =
-            generate_rel_update_input(&project_type, &project_board_rel);
+            generate_rel_update_input(&project_type, project_board_rel);
         assert!(project_board_update_input.type_name == "ProjectBoardUpdateInput");
         assert!(project_board_update_input.type_kind == TypeKind::Input);
         assert!(project_board_update_input.props.len() == 2);
@@ -4041,7 +4136,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_delete_input_name(&project_type, &project_owner_rel)
+            fmt_rel_delete_input_name(&project_type, project_owner_rel)
                 == "ProjectOwnerDeleteInput"
         );
     }
@@ -4058,7 +4153,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_delete_input =
-            generate_rel_delete_input(&project_type, &project_owner_rel);
+            generate_rel_delete_input(&project_type, project_owner_rel);
         assert!(project_owner_delete_input.type_name == "ProjectOwnerDeleteInput");
         let pmatch = project_owner_delete_input.props.get("MATCH").unwrap();
         assert!(pmatch.name == "MATCH");
@@ -4088,7 +4183,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_src_delete_mutation_input_name(&project_type, &project_owner_rel)
+            fmt_rel_src_delete_mutation_input_name(&project_type, project_owner_rel)
                 == "ProjectOwnerSrcDeleteMutationInput"
         );
     }
@@ -4103,7 +4198,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_src_delete_mutation_input =
-            generate_rel_src_delete_mutation_input(&project_type, &project_owner_rel);
+            generate_rel_src_delete_mutation_input(&project_type, project_owner_rel);
         assert!(
             project_owner_src_delete_mutation_input.type_name
                 == "ProjectOwnerSrcDeleteMutationInput"
@@ -4126,7 +4221,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_dst_delete_mutation_input_name(&project_type, &project_owner_rel)
+            fmt_rel_dst_delete_mutation_input_name(&project_type, project_owner_rel)
                 == "ProjectOwnerDstDeleteMutationInput"
         );
     }
@@ -4141,7 +4236,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_dst_delete_mutation_input =
-            generate_rel_dst_delete_mutation_input(&project_type, &project_owner_rel);
+            generate_rel_dst_delete_mutation_input(&project_type, project_owner_rel);
         assert!(
             project_owner_dst_delete_mutation_input.type_name
                 == "ProjectOwnerDstDeleteMutationInput"
@@ -4166,7 +4261,7 @@ mod tests {
         */
         let project_issues_rel = project_type.rels().find(|&r| r.name() == "issues").unwrap();
         let project_issues_dst_delete_mutation_input =
-            generate_rel_dst_delete_mutation_input(&project_type, &project_issues_rel);
+            generate_rel_dst_delete_mutation_input(&project_type, project_issues_rel);
         assert!(
             project_issues_dst_delete_mutation_input.type_name
                 == "ProjectIssuesDstDeleteMutationInput"
@@ -4199,9 +4294,9 @@ mod tests {
     fn test_fmt_rel_read_endpoint_name() {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
-        assert!(fmt_rel_read_endpoint_name(&project_type, &project_owner_rel) == "ProjectOwner");
+        assert!(fmt_rel_read_endpoint_name(&project_type, project_owner_rel) == "ProjectOwner");
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
-        assert!(fmt_rel_read_endpoint_name(&project_type, &project_board_rel) == "ProjectBoard");
+        assert!(fmt_rel_read_endpoint_name(&project_type, project_board_rel) == "ProjectBoard");
     }
 
     /// Passes if the right schema elements are generated
@@ -4213,7 +4308,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_read_endpoint =
-            generate_rel_read_endpoint(&project_type, &project_owner_rel);
+            generate_rel_read_endpoint(&project_type, project_owner_rel);
         assert!(project_owner_read_endpoint.name == "ProjectOwner");
         assert!(match &project_owner_read_endpoint.kind {
             PropertyKind::Rel { rel_name } => rel_name == "owner",
@@ -4236,11 +4331,11 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_create_endpoint_name(&project_type, &project_owner_rel) == "ProjectOwnerCreate"
+            fmt_rel_create_endpoint_name(&project_type, project_owner_rel) == "ProjectOwnerCreate"
         );
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
         assert!(
-            fmt_rel_create_endpoint_name(&project_type, &project_board_rel) == "ProjectBoardCreate"
+            fmt_rel_create_endpoint_name(&project_type, project_board_rel) == "ProjectBoardCreate"
         );
     }
 
@@ -4253,7 +4348,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_create_endpoint =
-            generate_rel_create_endpoint(&project_type, &project_owner_rel);
+            generate_rel_create_endpoint(&project_type, project_owner_rel);
         assert!(project_owner_create_endpoint.name == "ProjectOwnerCreate");
         assert!(match &project_owner_create_endpoint.kind {
             PropertyKind::RelCreateMutation {
@@ -4281,11 +4376,11 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_update_endpoint_name(&project_type, &project_owner_rel) == "ProjectOwnerUpdate"
+            fmt_rel_update_endpoint_name(&project_type, project_owner_rel) == "ProjectOwnerUpdate"
         );
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
         assert!(
-            fmt_rel_update_endpoint_name(&project_type, &project_board_rel) == "ProjectBoardUpdate"
+            fmt_rel_update_endpoint_name(&project_type, project_board_rel) == "ProjectBoardUpdate"
         );
     }
 
@@ -4298,7 +4393,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_update_endpoint =
-            generate_rel_update_endpoint(&project_type, &project_owner_rel);
+            generate_rel_update_endpoint(&project_type, project_owner_rel);
         assert!(project_owner_update_endpoint.name == "ProjectOwnerUpdate");
         assert!(match &project_owner_update_endpoint.kind {
             PropertyKind::RelUpdateMutation {
@@ -4326,11 +4421,11 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         assert!(
-            fmt_rel_delete_endpoint_name(&project_type, &project_owner_rel) == "ProjectOwnerDelete"
+            fmt_rel_delete_endpoint_name(&project_type, project_owner_rel) == "ProjectOwnerDelete"
         );
         let project_board_rel = project_type.rels().find(|&r| r.name() == "board").unwrap();
         assert!(
-            fmt_rel_delete_endpoint_name(&project_type, &project_board_rel) == "ProjectBoardDelete"
+            fmt_rel_delete_endpoint_name(&project_type, project_board_rel) == "ProjectBoardDelete"
         );
     }
 
@@ -4343,7 +4438,7 @@ mod tests {
         let project_type = mock_project_type();
         let project_owner_rel = project_type.rels().find(|&r| r.name() == "owner").unwrap();
         let project_owner_delete_endpoint =
-            generate_rel_delete_endpoint(&project_type, &project_owner_rel);
+            generate_rel_delete_endpoint(&project_type, project_owner_rel);
         assert!(project_owner_delete_endpoint.name == "ProjectOwnerDelete");
         assert!(match &project_owner_delete_endpoint.kind {
             PropertyKind::RelDeleteMutation {


### PR DESCRIPTION
Provides more granular hiding of properties, so that instead of an all-or-nothing decision, properties can be separately hidden from any or all of the node output format (output from API service to client), the creation input, the update input, and the match query input.