### PR TITLE
Hidden props

### DIFF
--- a/src/engine/objects/mod.rs
+++ b/src/engine/objects/mod.rs
@@ -84,6 +84,7 @@ where
 
         let args = props
             .iter()
+            .filter(|p| !p.hidden())
             .map(|p| match (p.type_name(), p.required(), p.list()) {
                 ("Boolean", false, false) => registry.arg::<Option<bool>>(p.name(), &()),
                 ("Boolean", false, true) => registry.arg::<Option<Vec<bool>>>(p.name(), &()),
@@ -283,6 +284,7 @@ where
 
         let fields = props
             .iter()
+            .filter(|p| !p.hidden())
             .map(|p| {
                 let f = match (p.type_name(), p.required(), p.list(), p.kind()) {
                     ("Boolean", false, false, _) => registry.field::<Option<bool>>(p.name(), &()),
@@ -801,6 +803,7 @@ where
 
         let fields = props
             .iter()
+            .filter(|p| !p.hidden())
             .map(|p| match (p.type_name(), p.required(), p.list()) {
                 ("ID", false, false) => registry.field::<Option<ID>>(p.name(), &()),
                 ("ID", false, true) => registry.field::<Option<Vec<ID>>>(p.name(), &()),

--- a/src/engine/schema.rs
+++ b/src/engine/schema.rs
@@ -411,7 +411,7 @@ fn generate_output_props(
                         p.type_name().to_string(),
                     )
                     .with_required(p.required())
-                    .with_hidden(p.uses().output())
+                    .with_hidden(!p.uses().output())
                     .with_list(p.list())
                     .with_resolver(r)
                     .with_validator(p.validator().cloned()),


### PR DESCRIPTION
There was a flaw both in the original hidden properties code and the more recent change introducing the `UsesFilter`. When a property was marked as hidden, or not used in a particular context, it was unavailable in the public GraphQL interface, as intended, but was also not accessible through Warpgrapher processing of properties for storage and retrieval from the database, which was not intended.  Basically, the default resolver code for CRUD operations checked that a property appeared in the schema as an input validation step.  This PR still suppresses properties from the public-facing GraphQL schema, but it allows working with those properties for storage and retrieval from the database.