### PR TITLE
Commit bugfix

### DIFF
--- a/src/engine/database/gremlin.rs
+++ b/src/engine/database/gremlin.rs
@@ -225,21 +225,12 @@ impl DatabasePool for GremlinPool {
     }
 
     async fn transaction(&self) -> Result<Self::TransactionType, Error> {
-        Ok(if self.sessions {
-            GremlinTransaction::new(
-                self.rw_pool.clone(),
-                self.long_ids,
-                self.partitions,
-                self.sessions,
-            )
-        } else {
-            GremlinTransaction::new(
-                self.rw_pool.clone(),
-                self.long_ids,
-                self.partitions,
-                self.sessions,
-            )
-        })
+        Ok(GremlinTransaction::new(
+            self.rw_pool.clone(),
+            self.long_ids,
+            self.partitions,
+            self.sessions,
+        ))
     }
 }
 
@@ -329,10 +320,12 @@ impl GremlinTransaction {
 #[async_trait]
 impl Transaction for GremlinTransaction {
     async fn begin(&mut self) -> Result<(), Error> {
-        self.client = self
-            .client
-            .create_session(Uuid::new_v4().to_hyphenated().to_string())
-            .await?;
+        if self.sessions {
+            self.client = self
+                .client
+                .create_session(Uuid::new_v4().to_hyphenated().to_string())
+                .await?;
+        }
         Ok(())
     }
 

--- a/src/engine/database/gremlin.rs
+++ b/src/engine/database/gremlin.rs
@@ -227,10 +227,7 @@ impl DatabasePool for GremlinPool {
     async fn transaction(&self) -> Result<Self::TransactionType, Error> {
         Ok(if self.sessions {
             GremlinTransaction::new(
-                self.rw_pool
-                    .clone()
-                    .create_session(Uuid::new_v4().to_hyphenated().to_string())
-                    .await?,
+                self.rw_pool.clone(),
                 self.long_ids,
                 self.partitions,
                 self.sessions,
@@ -332,6 +329,10 @@ impl GremlinTransaction {
 #[async_trait]
 impl Transaction for GremlinTransaction {
     async fn begin(&mut self) -> Result<(), Error> {
+        self.client = self
+            .client
+            .create_session(Uuid::new_v4().to_hyphenated().to_string())
+            .await?;
         Ok(())
     }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -455,7 +455,6 @@ where
                 )
                 .await?;
             }
-            dbtx.commit().await?;
             std::mem::drop(dbtx);
         }
 
@@ -503,7 +502,6 @@ where
                 )
                 .await?;
             }
-            dbtx.commit().await?;
             std::mem::drop(dbtx);
         }
 

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -3,7 +3,7 @@
 use super::error::Error;
 use config::Configuration;
 use context::{GraphQLContext, RequestContext};
-use database::{CrudOperation, DatabaseEndpoint, DatabasePool, Transaction};
+use database::{CrudOperation, DatabaseEndpoint, DatabasePool};
 use events::{EventFacade, EventHandlerBag};
 use juniper::http::GraphQLRequest;
 use log::debug;

--- a/tests/node_resolver_test.rs
+++ b/tests/node_resolver_test.rs
@@ -156,6 +156,25 @@ async fn read_query<RequestCtx: RequestContext>(mut client: Client<RequestCtx>) 
     assert_eq!(projects_a[0].get("name").unwrap(), "Project1");
 }
 
+/// Passes if reading a non-existent node returns an empty array rather than an error
+#[wg_test]
+#[allow(dead_code)]
+async fn read_with_no_result<RequestCtx: RequestContext>(mut client: Client<RequestCtx>) {
+    let projects = client
+        .read_node(
+            "Project",
+            "__typename id name description status priority estimate active",
+            Some("1234"),
+            Some(&json!({"id": {"EQ": "1234"}})),
+        )
+        .await
+        .unwrap();
+
+    assert!(projects.is_array());
+    let projects_a = projects.as_array().unwrap();
+    assert!(projects_a.is_empty());
+}
+
 /// Passes if resolvers can handle a shape that reads a property that is not
 /// present on the model object.
 #[wg_test]


### PR DESCRIPTION
- Fixes a bug in which Warpgrapher tried to lose transactions after pre-request and post-request event handlers. This caused an error with Neo4J when trying to close a non-existent transaction.
- Moved the creation of a session (and thus transaction) in Gremlin to the `begin` method call, where it belongs, rather than upon creation of the transaction struct.
- Fixed a bug in which a single N+1 loader read that failed to find an object would cause an error that aborts all load operations in the batch. Instead, objects not found are correctly returns as nulls / empty arrays, rather than errors.