### PR TITLE
Event Hooks for Post-Subgraph Operations

### DIFF
--- a/book/src/engine/dynamic_rels.md
+++ b/book/src/engine/dynamic_rels.md
@@ -34,6 +34,8 @@ The following GraphQL query uses the dynamic resolver defined above.
 {{#include ../../../examples/dynamic_rels/main.rs:88:107}}
 ```
 
+Note that the Warpgrapher engine does not create a top level relationship query for properties that have custom resolvers. For example, there is no `ProjectTopContributor` root level relationship query. This is because the standard Warpgarpher resolver generated for a relationship query would not know how to handle the dynamic relationship.
+
 ## Full Example Source
 
 See below for the full source code to the example above.

--- a/book/src/engine/event_handlers.md
+++ b/book/src/engine/event_handlers.md
@@ -1,6 +1,6 @@
 # Event Handlers
 
-The earlier sections of the book covered a great many options for customizing the behavior of Warpgrapher, including input validation, request context, custom endpoints, and dynamic properties and relationships. Warpgrapher offers an additional API, the event handling API, to modify Warpgrapher's behavior at almost every point in the lifecycle of a request. Event handlers may be added before `Engine` creation, before or after request handling, and before or after nodes ore relationsihps are created, read, updated, or deleted. This section will introduce the event handling API using an extended example of implementing a very simple authorization model. Each data record will be owned by one user, and only that user is entitled to read or modify that record.
+The earlier sections of the book covered a great many options for customizing the behavior of Warpgrapher, including input validation, request context, custom endpoints, and dynamic properties and relationships. Warpgrapher offers an additional API, the event handling API, to modify Warpgrapher's behavior at almost every point in the lifecycle of a request. Event handlers may be added before `Engine` creation, before or after request handling, and before or after nodes or relationships are created, read, updated, or deleted. This section will introduce the event handling API using an extended example of implementing a very simple authorization model. Each data record will be owned by one user, and only that user is entitled to read or modify that record.
 
 ## Configuration
 


### PR DESCRIPTION
Prior to this PR, we had event hooks that invoked handlers after nodes and relationships are added and updated. The implementation invokes the event handlers immediately after the creation of a node, or immediately after the update or a node or rel, prior to any operations being done on source nodes, destination nodes, or relationships further down `input` tree provided in the request. In some use cases, this behavior is exactly what's expected and desired. In some use cases, however, it is helpful to have a post-create or post-update handler that follows after all creation or update operations have taken place throughout the sub-graph described the the query input, as modified by any pre-event hooks that may have been called. This PR adds post subgraph creation and update hooks.