### PR TITLE
Fix queries relying on multi-hop path destination properties.

### DIFF
--- a/src/engine/objects/resolvers/visitors.rs
+++ b/src/engine/objects/resolvers/visitors.rs
@@ -1249,7 +1249,11 @@ async fn visit_rel_dst_query_input<RequestCtx: RequestContext>(
 
             Ok(Some(
                 visit_node_query_input::<RequestCtx>(
-                    node_var,
+                    &NodeQueryVar::new(
+                        Some(k.to_string()),
+                        node_var.base().to_string(),
+                        node_var.suffix().to_string(),
+                    ),
                     Some(v),
                     options,
                     &Info::new(p.type_name().to_owned(), info.type_defs()),
@@ -1504,7 +1508,11 @@ async fn visit_rel_src_query_input<RequestCtx: RequestContext>(
             let p = info.type_def()?.property(&k)?;
 
             let fragment = visit_node_query_input::<RequestCtx>(
-                node_var,
+                &NodeQueryVar::new(
+                    Some(k.to_string()),
+                    node_var.base().to_string(),
+                    node_var.suffix().to_string(),
+                ),
                 Some(v),
                 options,
                 &Info::new(p.type_name().to_owned(), info.type_defs()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! For an introduction and tutorials, see the [Warpgrapher Book](https://warpforge.github.io/warpgrapher/).
 //!
 //! Warpgrapher is published as [Cargo Crate](https://crates.io/crates/warpgrapher).
-//! 
+//!
 //! To browse source code, report issues, or contribute to the project, see the [GitHub Repository](https://github.com/warpforge/warpgrapher).
 
 #![doc(html_root_url = "https://docs.rs/warpgrapher/0.11.0")]

--- a/tests/event_handler_test.rs
+++ b/tests/event_handler_test.rs
@@ -842,12 +842,7 @@ async fn test_after_rel_subgraph_update_handler() {
     let mut client = cypher_test_client_with_events("./tests/fixtures/minimal.yml", ehb).await;
 
     client
-        .create_node(
-            "Project",
-            "id name",
-            &json!({"name": "Project Zero"}),
-            None,
-        )
+        .create_node("Project", "id name", &json!({"name": "Project Zero"}), None)
         .await
         .unwrap();
     client


### PR DESCRIPTION
This change fixed a bug that prevented queries from including properties on the destinations of nodes multiple hops away from the source.